### PR TITLE
Option to invert bit bang serial logic.

### DIFF
--- a/command.c
+++ b/command.c
@@ -146,6 +146,7 @@ cmdInfo_t cmdInfo[]=
    {PI_CMD_SLR,   "SLR",   121, 6}, // gpioSerialRead
    {PI_CMD_SLRC,  "SLRC",  112, 0}, // gpioSerialReadClose
    {PI_CMD_SLRO,  "SLRO",  131, 0}, // gpioSerialReadOpen
+   {PI_CMD_SLRI,  "SLRI",  121, 0}, // gpioSerialReadInvert
 
    {PI_CMD_SPIC,  "SPIC",  112, 0}, // spiClose
    {PI_CMD_SPIO,  "SPIO",  131, 2}, // spiOpen
@@ -305,6 +306,7 @@ SERWB h byte        Write byte to serial handle\n\
 SLR g v          Read bit bang serial data from gpio\n\
 SLRC g           Close gpio for bit bang serial data\n\
 SLRO g baud bitlen | Open gpio for bit bang serial data\n\
+SLRI g invert    Invert serial logic (1 invert, 0 normal)\n\
 SPIC h           SPI close handle\n\
 SPIO channel baud flags | SPI open channel at baud with flags\n\
 SPIR h v         SPI read bytes from handle\n\
@@ -466,6 +468,8 @@ static errInfo_t errInfo[]=
    {PI_CHAIN_NESTING    , "chain counters nested too deeply"},
    {PI_CHAIN_TOO_BIG    , "chain is too long"},
    {PI_DEPRECATED       , "deprecated function removed"},
+   {PI_NOT_IN_SER_MODE  , "gpio not opened for bit-bang serial"},
+   {PI_BAD_SER_INVERT   , "bit-bang serial invert not 0 or 1"},
 
 };
 
@@ -662,7 +666,7 @@ int cmdParse(
          break;
 
       case 121: /* HC I2CRD  I2CRR  I2CRW  I2CWB I2CWQ  P  PFS  PRS
-                   PWM  S  SERVO  SLR  W  WDOG  WRITE
+                   PWM  S  SERVO  SLR  SLRI  W  WDOG  WRITE
 
                    Two positive parameters.
                 */

--- a/pigpio.3
+++ b/pigpio.3
@@ -2175,6 +2175,26 @@ For \fBdata_bits\fP 9-16 there will be two bytes per character.
 .br
 For \fBdata_bits\fP 17-32 there will be four bytes per character.
 
+.IP "\fBint gpioSerialReadInvert(unsigned user_gpio, unsigned invert)\fP"
+.IP "" 4
+This function inverts the serial logic for bit bang reading of serial data.
+
+.br
+
+.br
+
+.EX
+user_gpio: 0-31, previously opened with \fBgpioSerialReadOpen\fP.
+   invert: 0-1, 1 invert , 0 normal.
+.br
+
+.EE
+
+.br
+
+.br
+Returns 0 if OK, otherwise PI_NOT_IN_SER_MODE or PI_BAD_SER_INVERT.
+
 .IP "\fBint gpioSerialReadClose(unsigned user_gpio)\fP"
 .IP "" 4
 This function closes a gpio for bit bang reading of serial data.
@@ -7310,6 +7330,10 @@ A 16-bit word value.
 .br
 
 .br
+#define PI_CMD_SLRI  94
+.br
+
+.br
 #define PI_CMD_NOIB  99
 .br
 
@@ -7564,6 +7588,10 @@ A 16-bit word value.
 #define PI_CHAIN_TOO_BIG   -119 // chain is too long
 .br
 #define PI_DEPRECATED      -120 // deprecated function removed
+.br
+#define PI_NOT_IN_SER_MODE -121 // gpio not opened for bit-bang serial
+.br
+#define PI_BAD_SER_INVERT  -122 // bit-bang serial invert not 0 or 1
 .br
 
 .br

--- a/pigpio.h
+++ b/pigpio.h
@@ -174,6 +174,7 @@ gpioNotifyPause            Pause notifications
 gpioNotifyClose            Close a notification
 
 gpioSerialReadOpen         Opens a gpio for bit bang serial reads
+gpioSerialReadInvert       Configures normal/inverted for serial reads
 gpioSerialRead             Reads bit bang serial data from a gpio
 gpioSerialReadClose        Closes a gpio for bit bang serial reads
 
@@ -548,6 +549,9 @@ typedef void *(gpioThreadFunc_t) (void *);
 
 #define PI_BB_SER_MIN_BAUD     50
 #define PI_BB_SER_MAX_BAUD 250000
+
+#define PI_BB_SER_NORMAL 0
+#define PI_BB_SER_INVERT 1
 
 #define PI_WAVE_MIN_BAUD      50
 #define PI_WAVE_MAX_BAUD 1000000
@@ -1819,6 +1823,26 @@ The serial data is returned in a cyclic buffer and is read using
 
 It is the caller's responsibility to read data from the cyclic buffer
 in a timely fashion.
+D*/
+
+/*F*/
+int gpioSerialReadInvert(unsigned user_gpio, unsigned invert);
+/*D
+This function configures the level logci for bit bang serial reads.
+
+Pass PI_BB_SER_INVERT to invert the serial logic.  Pass PI_BB_SER_NORMAL for
+normal logic.  Default is PI_BB_SER_NORMAL.
+
+. .
+user_gpio: 0-31
+invert: 0-1
+. .
+
+Returns 0 if OK, otherwise PI_BAD_USER_GPIO, PI_GPIO_IN_USE,
+PI_NOT_IN_SER_MODE, or PI_BAD_SER_INVERT.
+
+The gpio must be opened for bit bang reading of serial data using
+[*gpioSerialReadOpen*] prior to calling this function.
 D*/
 
 
@@ -4581,6 +4605,8 @@ PARAMS*/
 
 #define PI_CMD_WVCHA 93
 
+#define PI_CMD_SLRI  94
+
 #define PI_CMD_NOIB  99
 
 /*DEF_E*/
@@ -4766,6 +4792,8 @@ after this command is issued.
 #define PI_CHAIN_NESTING   -118 // chain counters nested too deeply
 #define PI_CHAIN_TOO_BIG   -119 // chain is too long
 #define PI_DEPRECATED      -120 // deprecated function removed
+#define PI_NOT_IN_SER_MODE -121 // gpio not opened for bit-bang serial
+#define PI_BAD_SER_INVERT  -122 // bit-bang serial invert not 0 or 1
 
 #define PI_PIGIF_ERR_0    -2000
 #define PI_PIGIF_ERR_99   -2099

--- a/pigpio.py
+++ b/pigpio.py
@@ -151,6 +151,7 @@ notify_close              Close a notification
 bb_serial_read_open       Open a gpio for bit bang serial reads
 bb_serial_read            Read bit bang serial data from  a gpio
 bb_serial_read_close      Close a gpio for bit bang serial reads
+bb_serial_invert          Invert serial logic (1 invert, 0 normal)
 
 hardware_clock            Start hardware clock on supported gpios
 hardware_PWM              Start hardware PWM on supported gpios
@@ -432,6 +433,8 @@ _PI_CMD_I2CZ =92
 
 _PI_CMD_WVCHA=93
 
+_PI_CMD_SLRI= 94
+
 # pigpio error numbers
 
 _PI_INIT_FAILED     =-1
@@ -555,6 +558,8 @@ PI_BAD_CHAIN_DELAY  =-117
 PI_CHAIN_NESTING    =-118
 PI_CHAIN_TOO_BIG    =-119
 PI_DEPRECATED       =-120
+PI_NOT_IN_SER_MODE  =-121
+PI_BAD_SER_INVERT   =-122
 
 # pigpio error text
 
@@ -677,6 +682,8 @@ _errors=[
    [PI_CHAIN_NESTING     , "chain counters nested too deeply"],
    [PI_CHAIN_TOO_BIG     , "chain is too long"],
    [PI_DEPRECATED        , "deprecated function removed"],
+   [PI_NOT_IN_SER_MODE   , "gpio not opened for bit-bang serial"],
+   [PI_BAD_SER_INVERT    , "bit-bang serial invert not 0 or 1"],
 
 ]
 
@@ -3324,6 +3331,19 @@ class pi():
       """
       return _u2i(_pigpio_command(self.sl, _PI_CMD_SLRC, user_gpio, 0))
 
+   def bb_serial_invert(self, user_gpio, invert):
+      """
+      Invert serial logic.
+
+      user_gpio:= 0-31 (opened in a prior call to [*bb_serial_read_open*])
+      invert:= 0-1 (1 invert, 0 normal)
+
+      ...
+      status = pi.bb_serial_invert(17, 1)
+      ...
+      """
+      return _u2i(_pigpio_command(self.sl, _PI_CMD_SLRI, user_gpio, invert, 0))
+
    def custom_1(self, arg1=0, arg2=0, argx=[]):
       """
       Calls a pigpio function customised by the user.
@@ -3718,6 +3738,8 @@ def xref():
    PI_CHAIN_NESTING = -118
    PI_CHAIN_TOO_BIG = -119
    PI_DEPRECATED = -120
+   PI_NOT_IN_SER_MODE  =-121
+   PI_BAD_SER_INVERT   =-122
    . .
 
    frequency: 0-40000

--- a/pigpiod_if.3
+++ b/pigpiod_if.3
@@ -2187,6 +2187,26 @@ user_gpio: 0-31, previously opened with \fBbb_serial_read_open\fP.
 .br
 Returns 0 if OK, otherwise PI_BAD_USER_GPIO, or PI_NOT_SERIAL_GPIO.
 
+.IP "\fBint bb_serial_invert(unsigned user_gpio, unsigned invert)\fP"
+.IP "" 4
+This function inverts the serial logic for bit bang reading of serial data.
+
+.br
+
+.br
+
+.EX
+user_gpio: 0-31, previously opened with \fBbb_serial_read_open\fP.
+   invert: 0-1, 1 invert , 0 normal.
+.br
+
+.EE
+
+.br
+
+.br
+Returns 0 if OK, otherwise PI_NOT_IN_SER_MODE or PI_BAD_SER_INVERT.
+
 .IP "\fBint i2c_open(unsigned i2c_bus, unsigned i2c_addr, unsigned i2c_flags)\fP"
 .IP "" 4
 This returns a handle for the device at address i2c_addr on bus i2c_bus.

--- a/pigpiod_if.c
+++ b/pigpiod_if.c
@@ -941,6 +941,9 @@ int bb_serial_read(unsigned user_gpio, void *buf, size_t bufSize)
 int bb_serial_read_close(unsigned user_gpio)
    {return pigpio_command(gPigCommand, PI_CMD_SLRC, user_gpio, 0, 1);}
 
+int bb_serial_invert(unsigned user_gpio, unsigned invert)
+   {return pigpio_command(gPigCommand, PI_CMD_SLRI, user_gpio, invert, 1);}
+
 int i2c_open(unsigned i2c_bus, unsigned i2c_addr, uint32_t i2c_flags)
 {
    gpioExtent_t ext[1];

--- a/pigpiod_if.h
+++ b/pigpiod_if.h
@@ -161,6 +161,7 @@ notify_close               Close a notification
 bb_serial_read_open        Opens a gpio for bit bang serial reads
 bb_serial_read             Reads bit bang serial data from a gpio
 bb_serial_read_close       Closes a gpio for bit bang serial reads
+bb_serial_invert           Invert serial logic (1 invert, 0 normal)
 
 hardware_clock             Start hardware clock on supported gpios
 hardware_PWM               Start hardware PWM on supported gpios
@@ -1499,6 +1500,19 @@ user_gpio: 0-31, previously opened with [*bb_serial_read_open*].
 . .
 
 Returns 0 if OK, otherwise PI_BAD_USER_GPIO, or PI_NOT_SERIAL_GPIO.
+D*/
+
+/*F*/
+int bb_serial_invert(unsigned user_gpio, unsigned invert);
+/*D
+This function inverts serial logic for big bang serial reads.
+
+. .
+user_gpio: 0-31, previously opened with [*bb_serial_read_open*].
+   invert: 0-1, 1 invert, 0 normal.
+. .
+
+Returns 0 if OK, otherwise PI_NOT_IN_SER_MODE or PI_BAD_SER_INVERT.
 D*/
 
 /*F*/

--- a/pigs.1
+++ b/pigs.1
@@ -2612,6 +2612,36 @@ ERROR: gpio already in use
 
 .br
 
+.IP "\fBSLRI u i\fP - Invert serial logic for bit bang serial data"
+.IP "" 4
+
+.br
+This command inverts the serial logic when reading bit bang serial data.
+
+.br
+Upon success nothing is returned.  On error a negative status code
+will be returned.
+
+.br
+The invert parameter is 1 for inverted signal, 0 for normal.
+
+.br
+
+\fBExample\fP
+.br
+
+.EX
+$ pigs slri 17 1
+.br
+
+.br
+$ pigs slri 17 0
+.br
+
+.EE
+
+.br
+
 .IP "\fBSPIC h\fP - SPI close handle"
 .IP "" 4
 


### PR DESCRIPTION
Adds new function, gpioSerialReadInvert(), to configure normal or inverted serial logic for bit bang serial reads.

Created new configuration function/command to avoid changing the call parameters/interface of existing functions/commands.

Unsure of the policy for changing command numbers within pigpio.h, selected free number to avoid changing existing command numbers.