### PR TITLE
small bug fix for python example

### DIFF
--- a/EXAMPLES/Python/GPIO_STATUS/gpio_status.py
+++ b/EXAMPLES/Python/GPIO_STATUS/gpio_status.py
@@ -3,6 +3,7 @@
 import time
 import curses
 import atexit
+import sys
 
 import pigpio 
 
@@ -17,6 +18,8 @@ def cleanup():
    pi.stop()
 
 pi = pigpio.pi()
+if not pi.connected:
+    sys.exit(1)
 
 stdscr = curses.initscr()
 curses.noecho()
@@ -43,7 +46,7 @@ while True:
       tally = cb[g].tally()
       mode = pi.get_mode(g)
 
-      col = (g / 11) * 25
+      col = (g // 11) * 25
       row = (g % 11) + 2
 
       stdscr.addstr(row, col, "{:2}".format(g), curses.A_BOLD)


### PR DESCRIPTION
The example `EXAMPLES/Python/GPIO_STATUS/gpio_status.py`  fails on Python3

```
Traceback (most recent call last):
                                    File "EXAMPLES/Python/GPIO_STATUS/gpio_status.py", line 49, in <module>
                               stdscr.addstr(row, col, "{:2}".format(g), curses.A_BOLD)
       TypeError: integer argument expected, got float
```

because in Python3 `col = (g / 11) * 25` is a `float` and not an `int`. 

I also added an explicit `sys.exit(1)` if no connection can be established to avoid nasty traceback.