### PR TITLE
Simplify cross-compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.o
+*.so
+pig2vcd
+pigpiod
+pigs
+x_pigpio
+x_pigpiod_if
+x_pigpiod_if2

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,9 @@ CC       = gcc
 AR       = ar
 RANLIB   = ranlib
 SIZE     = size
-SHLIB    = gcc -shared
-STRIPLIB = strip --strip-unneeded
+SHLIB    = $(CC) -shared
+STRIP    = strip
+STRIPLIB = $(STRIP) --strip-unneeded
 
 CFLAGS	+= -O3 -Wall -pthread
 

--- a/Makefile
+++ b/Makefile
@@ -60,12 +60,15 @@ x_pigpiod_if2:	x_pigpiod_if2.o $(LIB3)
 
 pigpiod:	pigpiod.o $(LIB1)
 	$(CC) -o pigpiod pigpiod.o $(LL1)
+	$(STRIP) pigpiod
 
 pigs:		pigs.o command.o
 	$(CC) -o pigs pigs.o command.o
+	$(STRIP) pigs
 
 pig2vcd:	pig2vcd.o
 	$(CC) -o pig2vcd pig2vcd.o
+	$(STRIP) pig2vcd
 
 clean:
 	rm -f *.o *.i *.s *~ $(ALL)
@@ -81,9 +84,9 @@ install:	$(ALL)
 	install -m 0755 libpigpiod_if.so  $(DESTDIR)$(libdir)
 	install -m 0755 libpigpiod_if2.so $(DESTDIR)$(libdir)
 	install -m 0755 -d                $(DESTDIR)$(bindir)
-	install -m 0755 -s pig2vcd        $(DESTDIR)$(bindir)
-	install -m 0755 -s pigpiod        $(DESTDIR)$(bindir)
-	install -m 0755 -s pigs           $(DESTDIR)$(bindir)
+	install -m 0755 pig2vcd           $(DESTDIR)$(bindir)
+	install -m 0755 pigpiod           $(DESTDIR)$(bindir)
+	install -m 0755 pigs              $(DESTDIR)$(bindir)
 	if which python2; then python2 setup.py install; fi
 	if which python3; then python3 setup.py install; fi
 	install -m 0755 -d                $(DESTDIR)$(mandir)/man1

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,14 @@
 #
-CC       = gcc
-AR       = ar
-RANLIB   = ranlib
-SIZE     = size
-SHLIB    = $(CC) -shared
-STRIP    = strip
-STRIPLIB = $(STRIP) --strip-unneeded
+# Set CROSS_PREFIX to prepend to all compiler tools at once for easier
+# cross-compilation.
+CROSS_PREFIX =
+CC           = $(CROSS_PREFIX)gcc
+AR           = $(CROSS_PREFIX)ar
+RANLIB       = $(CROSS_PREFIX)ranlib
+SIZE         = $(CROSS_PREFIX)size
+STRIP        = $(CROSS_PREFIX)strip
+SHLIB        = $(CC) -shared
+STRIPLIB     = $(STRIP) --strip-unneeded
 
 CFLAGS	+= -O3 -Wall -pthread
 


### PR DESCRIPTION
This simplifies cross-compilation by cleaning up redundancies in vars, making stripping explicit (rather than done by install), and adding a CROSS_PREFIX var to simplify configuration.  Now, to cross-compile for Raspberry Pi, run:

make CROSS_PREFIX=arm-linux-gnueabi-
sudo make prefix=/usr/arm-linux-gnueabi install

Closes #91