### PR TITLE
Add pycache and build to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ pigs
 x_pigpio
 x_pigpiod_if
 x_pigpiod_if2
+__pycache__
+build


### PR DESCRIPTION
These get created when running `sudo python setup.py install` - best to make sure they don't get added to the repo by mistake.