### PR TITLE
fix localhost socket only not working

### DIFF
--- a/pigpiod_if2.c
+++ b/pigpiod_if2.c
@@ -717,7 +717,12 @@ int pigpio_start(char *addrStr, char *portStr)
    {
       if (!gPiInUse[pi]) break;
    }
-
+   
+   if ((!addrStr) || (strlen(addrStr) == 0))
+   {
+      addrStr = "localhost";
+   }
+   
    if (pi >= MAX_PI) return pigif_too_many_pis;
 
    gPiInUse[pi] = 1;


### PR DESCRIPTION
if the pigpio daemon only listens to localhost sockets, the client failed to connect - this is the propesed fix by the author, see https://github.com/joan2937/pigpio/issues/119