### PR TITLE
add interface to query library initialisation

### DIFF
--- a/pigpio.c
+++ b/pigpio.c
@@ -8438,6 +8438,14 @@ int gpioInitialise(void)
 
 /* ----------------------------------------------------------------------- */
 
+int gpioIsInitialised(void)
+{
+   if (libInitialised) return 0;
+   return PI_NOT_INITIALISED;
+}
+
+/* ----------------------------------------------------------------------- */
+
 void gpioTerminate(void)
 {
    int i;

--- a/pigpio.h
+++ b/pigpio.h
@@ -100,6 +100,7 @@ with the following exceptions:
 [*gpioCfg**]
 [*gpioVersion*]
 [*gpioHardwareRevision*]
+[*gpioIsInitialised*]
 . .
 
 If the library is not initialised all but the [*gpioCfg**],
@@ -116,6 +117,7 @@ TEXT*/
 ESSENTIAL
 
 gpioInitialise             Initialise library
+gpioIsInitialised          Test if library is initialised        
 gpioTerminate              Stop library
 
 BEGINNER
@@ -923,6 +925,7 @@ with the following exceptions:
 [*gpioCfg**]
 [*gpioVersion*]
 [*gpioHardwareRevision*]
+[*gpioIsInitialised*]
 . .
 
 ...
@@ -937,6 +940,26 @@ else
 ...
 D*/
 
+/*F*/
+int gpioIsInitialised(void);
+/*D
+Tests if the library is initialised.
+
+Returns 0 if OK, otherwise PI_NOT_INITIALISED.
+
+gpioIsInitialised can be called at any time.
+
+...
+if (gpioIsInitialised() < 0)
+{
+   // pigpio is not initialised.
+}
+else
+{
+   // pigpio initialised okay.
+}
+...
+D*/
 
 /*F*/
 void gpioTerminate(void);


### PR DESCRIPTION
This pull request adds a function to query if the library is (still) initialised ok.
I needed this to work around an ugly glitch: I'm using pigpio's SPI in c++ with threads and in the destructor of my SPI object I would of course close my _spi_handle:
```
myspi::~myspi() {
   spiClose(_spi_handle);
}
```
This yields nasty error messages if my program is terminated by a signal (SIGINT or whatever) and the library is (via it's signal handler) already un-initialised but my thread tries to spiClose in it's destructor. 
Testing if the library is still initialised with the added library call circumvented the problem:
```
myspi::~myspi() {
  if (gpioIsInitialised()==0)
      spiClose(_spi_handle);
}
```