### PR TITLE
Additional pigpiod command line option "-m" to disable the alerts

### DIFF
--- a/command.c
+++ b/command.c
@@ -442,7 +442,7 @@ static errInfo_t errInfo[]=
    {PI_BAD_PATHNAME     , "can't open pathname"},
    {PI_NO_HANDLE        , "no handle available"},
    {PI_BAD_HANDLE       , "unknown handle"},
-   {PI_BAD_IF_FLAGS     , "ifFlags > 3"},
+   {PI_BAD_IF_FLAGS     , "ifFlags > 4"},
    {PI_BAD_CHANNEL      , "DMA channel not 0-14"},
    {PI_BAD_SOCKET_PORT  , "socket port not 1024-30000"},
    {PI_BAD_FIFO_COMMAND , "unknown fifo command"},

--- a/pigpio.3
+++ b/pigpio.3
@@ -9796,7 +9796,7 @@ A 16-bit word value.
 .br
 #define PI_BAD_HANDLE       -25 // unknown handle
 .br
-#define PI_BAD_IF_FLAGS     -26 // ifFlags > 3
+#define PI_BAD_IF_FLAGS     -26 // ifFlags > 4
 .br
 #define PI_BAD_CHANNEL      -27 // DMA channel not 0-14
 .br

--- a/pigpio.c
+++ b/pigpio.c
@@ -8140,10 +8140,13 @@ int initInitialise(void)
    if (pthread_attr_setstacksize(&pthAttr, STACK_SIZE))
       SOFT_ERROR(PI_INIT_FAILED, "pthread_attr_setstacksize failed (%m)");
 
-   if (pthread_create(&pthAlert, &pthAttr, pthAlertThread, &i))
-      SOFT_ERROR(PI_INIT_FAILED, "pthread_create alert failed (%m)");
+   if (!(gpioCfg.ifFlags & PI_DISABLE_ALERT))
+   {
+      if (pthread_create(&pthAlert, &pthAttr, pthAlertThread, &i))
+         SOFT_ERROR(PI_INIT_FAILED, "pthread_create alert failed (%m)");
 
-   pthAlertRunning = PI_THREAD_STARTED;
+      pthAlertRunning = PI_THREAD_STARTED;
+   }
 
    if (!(gpioCfg.ifFlags & PI_DISABLE_FIFO_IF))
    {

--- a/pigpio.c
+++ b/pigpio.c
@@ -8115,10 +8115,13 @@ int initInitialise(void)
    if (pthread_attr_setstacksize(&pthAttr, STACK_SIZE))
       SOFT_ERROR(PI_INIT_FAILED, "pthread_attr_setstacksize failed (%m)");
 
-   if (pthread_create(&pthAlert, &pthAttr, pthAlertThread, &i))
-      SOFT_ERROR(PI_INIT_FAILED, "pthread_create alert failed (%m)");
+   if (!(gpioCfg.ifFlags & PI_DISABLE_ALERT))
+   {
+      if (pthread_create(&pthAlert, &pthAttr, pthAlertThread, &i))
+         SOFT_ERROR(PI_INIT_FAILED, "pthread_create alert failed (%m)");
 
-   pthAlertRunning = 1;
+      pthAlertRunning = 1;
+   }
 
    if (!(gpioCfg.ifFlags & PI_DISABLE_FIFO_IF))
    {

--- a/pigpio.c
+++ b/pigpio.c
@@ -13328,7 +13328,7 @@ int gpioCfgInterfaces(unsigned ifFlags)
 
    CHECK_NOT_INITED;
 
-   if (ifFlags > 7)
+   if (ifFlags > 15)
       SOFT_ERROR(PI_BAD_IF_FLAGS, "bad ifFlags (%X)", ifFlags);
 
    gpioCfg.ifFlags = ifFlags;

--- a/pigpio.c
+++ b/pigpio.c
@@ -13380,7 +13380,7 @@ int gpioCfgInterfaces(unsigned ifFlags)
 
    CHECK_NOT_INITED;
 
-   if (ifFlags > 7)
+   if (ifFlags > 15)
       SOFT_ERROR(PI_BAD_IF_FLAGS, "bad ifFlags (%X)", ifFlags);
 
    gpioCfg.ifFlags = ifFlags;

--- a/pigpio.h
+++ b/pigpio.h
@@ -846,6 +846,7 @@ typedef void *(gpioThreadFunc_t) (void *);
 #define PI_DISABLE_FIFO_IF   1
 #define PI_DISABLE_SOCK_IF   2
 #define PI_LOCALHOST_SOCK_IF 4
+#define PI_DISABLE_ALERT     8
 
 /* memAllocMode */
 

--- a/pigpio.h
+++ b/pigpio.h
@@ -6143,7 +6143,7 @@ after this command is issued.
 #define PI_BAD_PATHNAME     -23 // can't open pathname
 #define PI_NO_HANDLE        -24 // no handle available
 #define PI_BAD_HANDLE       -25 // unknown handle
-#define PI_BAD_IF_FLAGS     -26 // ifFlags > 3
+#define PI_BAD_IF_FLAGS     -26 // ifFlags > 4
 #define PI_BAD_CHANNEL      -27 // DMA channel not 0-14
 #define PI_BAD_PRIM_CHANNEL -27 // DMA primary channel not 0-14
 #define PI_BAD_SOCKET_PORT  -28 // socket port not 1024-32000

--- a/pigpio.py
+++ b/pigpio.py
@@ -712,7 +712,7 @@ _errors=[
    [_PI_BAD_PATHNAME     , "can't open pathname"],
    [PI_NO_HANDLE         , "no handle available"],
    [PI_BAD_HANDLE        , "unknown handle"],
-   [_PI_BAD_IF_FLAGS     , "ifFlags > 3"],
+   [_PI_BAD_IF_FLAGS     , "ifFlags > 4"],
    [_PI_BAD_CHANNEL      , "DMA channel not 0-14"],
    [_PI_BAD_SOCKET_PORT  , "socket port not 1024-30000"],
    [_PI_BAD_FIFO_COMMAND , "unknown fifo command"],

--- a/pigpiod.c
+++ b/pigpiod.c
@@ -103,6 +103,7 @@ void usage()
       "   -k,         disable socket interface,          default enabled\n" \
       "   -l,         localhost socket only              default local+remote\n" \
       "   -n IP addr, allow address, name or dotted,     default allow all\n" \
+      "   -m,         disable alerts                     default enabled\n" \
       "   -p value,   socket port, 1024-32000,           default 8888\n" \
       "   -s value,   sample rate, 1, 2, 4, 5, 8, or 10, default 5\n" \
       "   -t value,   clock peripheral, 0=PWM 1=PCM,     default PCM\n" \
@@ -162,7 +163,7 @@ static void initOpts(int argc, char *argv[])
    uint32_t addr;
    int64_t mask;
 
-   while ((opt = getopt(argc, argv, "a:b:c:d:e:fgkln:p:s:t:x:vV")) != -1)
+   while ((opt = getopt(argc, argv, "a:b:c:d:e:fgkln:mp:s:t:x:vV")) != -1)
    {
       switch (opt)
       {

--- a/pigpiod.c
+++ b/pigpiod.c
@@ -217,6 +217,10 @@ static void initOpts(int argc, char *argv[])
             ifFlags |= PI_LOCALHOST_SOCK_IF;
             break; 
 
+         case 'm':
+            ifFlags |= PI_DISABLE_ALERT;
+            break; 
+
          case 'n':
             addr = checkAddr(optarg);
             if (addr && (numSockNetAddr<MAX_CONNECT_ADDRESSES))


### PR DESCRIPTION
I use the pigpio library only to transmit 433MHz codes of a remote control.

To optimize CPU usage I added a new command line option "-m" for the pigpiod daemon.
This option disables the alerts thread and reduces CPU usage from 6-7% to 1.5% on my RPI 2.

It would be great when you could merge this to master.