### PR TITLE
Add systemd service file

### DIFF
--- a/util/pigpiod.service
+++ b/util/pigpiod.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Pigpio daemon
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/pigpiod -g
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR adds a pigpiod.service file in the `util` directory.

This file can be installed in `/usr/lib/systemd/system` on systemd-enabled systems to add a `pigpiod` service that can be used to manage the pigpiod daemon.