### PR TITLE
Allow to configure internals to remove signals handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ mandir = $(prefix)/man
 
 all:	$(ALL)
 
+lib:	$(LIB)
+
 pigpio.o: pigpio.c pigpio.h command.h custom.cext
 	$(CC) $(CFLAGS) -fpic -c -o pigpio.o pigpio.c
 

--- a/pigpio.h
+++ b/pigpio.h
@@ -31,7 +31,7 @@ For more information, please refer to <http://unlicense.org/>
 #include <stdint.h>
 #include <pthread.h>
 
-#define PIGPIO_VERSION 64
+#define PIGPIO_VERSION 65
 
 /*TEXT
 
@@ -864,8 +864,10 @@ typedef void *(gpioThreadFunc_t) (void *);
 #define PI_CFG_ALERT_FREQ        4 /* bits 4-7 */
 #define PI_CFG_RT_PRIORITY       (1<<8)
 #define PI_CFG_STATS             (1<<9)
+#define PI_CFG_SIGHANDLER        (1<<10)
 
-#define PI_CFG_ILLEGAL_VAL       (1<<10)
+#define PI_CFG_ILLEGAL_VAL       (1<<11)
+
 
 /* gpioISR */
 


### PR DESCRIPTION
Previously with PR https://github.com/joan2937/pigpio/pull/8 the lib can be conditionnaly compiled to remove signal handling.
This PR allows to configure this behavior before library is initialized.
We use the internal cfg bit `1<<10`: 1=Handle signals (default), 0=Do not handle signals (as if previously compiled with `EMBEDDED_IN_VM`.
Flag can be changed before calling `gpioInitialise`.