### PR TITLE
cmake: include find_package_handle_standard_args

### DIFF
--- a/util/Findpigpio.cmake
+++ b/util/Findpigpio.cmake
@@ -25,6 +25,7 @@ set(pigpio_INCLUDES     ${pigpio_INCLUDE_DIR})
 
 # Handle REQUIRED, QUIET, and version arguments 
 # and set the <packagename>_FOUND variable.
+include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(pigpio 
     DEFAULT_MSG 
     pigpio_INCLUDE_DIR pigpio_LIBRARY pigpiod_if_LIBRARY pigpiod_if2_LIBRARY)


### PR DESCRIPTION
The Findpigpio.cmake script doesn't work for me if this is missing (CMake 3.9.4 on Arch Linux ARM).