### PR TITLE
Allow 3-op script cmds to use regs as 3rd operand.

### DIFF
--- a/command.c
+++ b/command.c
@@ -890,11 +890,11 @@ int cmdParse(
                 */
          ctl->eaten += getNum(buf+ctl->eaten, &p[1], &ctl->opt[1]);
          ctl->eaten += getNum(buf+ctl->eaten, &p[2], &ctl->opt[2]);
-         ctl->eaten += getNum(buf+ctl->eaten, &tp1, &to1);
+         ctl->eaten += getNum(buf+ctl->eaten, &tp1, &ctl->opt[3]);
 
          if ((ctl->opt[1] > 0) && ((int)p[1] >= 0) &&
              (ctl->opt[2] > 0) && ((int)p[2] >= 0) &&
-             (to1 == CMD_NUMERIC) && ((int)tp1 >= 0))
+             (ctl->opt[3] > 0) && ((int)tp1 >= 0))
          {
             p[3] = 4;
             memcpy(ext, &tp1, 4);

--- a/pigpio.c
+++ b/pigpio.c
@@ -6496,7 +6496,7 @@ static void *pthScript(void *x)
 {
    gpioScript_t *s;
    cmdInstr_t instr;
-   int p1, p2, p1o, p2o, *t1, *t2;
+   int p1, p2, p1o, p2o, p3o, *t1, *t2;
    int PC, A, F, SP;
    int S[PI_SCRIPT_STACK_SIZE];
    char buf[CMD_MAX_EXTENSION];
@@ -6542,7 +6542,17 @@ static void *pthScript(void *x)
          {
             if (instr.p[3])
             {
-               memcpy(buf, (char *)instr.p[4], instr.p[3]);
+               if ((instr.p[3] == sizeof(int)) && ((instr.opt[3] == CMD_VAR) || (instr.opt[3] == CMD_PAR)))
+               {
+                  /* Hack to allow register use in 3rd parameter */
+                  memcpy((char*)&p3o, (char *)instr.p[4], sizeof(int));
+                  if (instr.opt[3] == CMD_VAR) memcpy(buf, (char *)&(s->script.var[p3o]), sizeof(int));
+                  else                         memcpy(buf, (char *)&(s->script.par[p3o]), sizeof(int));
+               }
+               else
+               {
+                  memcpy(buf, (char *)instr.p[4], instr.p[3]);
+               }
             }
 
             A = myDoCommand(instr.p, sizeof(buf)-1, buf);


### PR DESCRIPTION
This is a simple hack to allow the 3rd operand of certain 3-op commands to be a register (v? / p?) rather than only a constant.  We utilize the previously-ignored opt[3] field for this purpose.  In my application this allows me to use the HP command with script-controlled duty cycle.

This change is entirely backward-compatible; no existing programs or scripts should be affected in any way.