### PR TITLE
Update reportedLevels prior to monitoring bits

### DIFF
--- a/pigpio.c
+++ b/pigpio.c
@@ -6371,6 +6371,7 @@ static void * pthAlertThread(void *x)
       }
 
       alertEmit(sample, reports, changedBits, sTick);
+      reportedLevel = sample[numSamples -1].level;
 
       if (totalSamples > gpioStats.maxSamples)
          gpioStats.maxSamples = numSamples;


### PR DESCRIPTION
This patch allows `reportedLevel` to be in sync with pin states just prior to starting alert notifications.  In my testing this seems to only be a problem in the first minute from starting the pigpio daemon - perhaps because the keep-alive packets have started the monitoring of pin levels.

The change seems innocuous but it would be appreciated if you could run a regression test to make sure it doesn't break anything.  I didn't provide a test script to validate results before and after applying the patch as it isn't easily extracted from my project.  I'll do so if you require a script before accepting this PR.