### PR TITLE
introduce sonames and fix make install/uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,7 @@ uninstall:
 	if which python2; then python2 setup.py install $(PYINSTALLARGS) --record /tmp/pigpio >/dev/null; sed 's!^!$(DESTDIR)!' < /tmp/pigpio | xargs rm -f >/dev/null; fi
 	if which python3; then python3 setup.py install $(PYINSTALLARGS) --record /tmp/pigpio >/dev/null; sed 's!^!$(DESTDIR)!' < /tmp/pigpio | xargs rm -f >/dev/null; fi
 	rm -f $(DESTDIR)$(mandir)/man1/pig*.1
+	rm -f $(DESTDIR)$(mandir)/man1/libpigpio*.1
 	rm -f $(DESTDIR)$(mandir)/man3/pig*.3
 ifeq ($(DESTDIR),)
 	ldconfig

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ STRIP        = $(CROSS_PREFIX)strip
 SHLIB        = $(CC) -shared
 STRIPLIB     = $(STRIP) --strip-unneeded
 
+SOVERSION    = 1
+
 CFLAGS	+= -O3 -Wall -pthread
 
 LIB1     = libpigpio.so
@@ -76,29 +78,34 @@ pig2vcd:	pig2vcd.o
 	$(STRIP) pig2vcd
 
 clean:
-	rm -f *.o *.i *.s *~ $(ALL)
+	rm -f *.o *.i *.s *~ $(ALL) *.so.$(SOVERSION)
 
 install:	$(ALL)
-	install -m 0755 -d                $(DESTDIR)/opt/pigpio/cgi
-	install -m 0755 -d                $(DESTDIR)$(includedir)
-	install -m 0644 pigpio.h          $(DESTDIR)$(includedir)
-	install -m 0644 pigpiod_if.h      $(DESTDIR)$(includedir)
-	install -m 0644 pigpiod_if2.h     $(DESTDIR)$(includedir)
-	install -m 0755 -d                $(DESTDIR)$(libdir)
-	install -m 0755 libpigpio.so      $(DESTDIR)$(libdir)
-	install -m 0755 libpigpiod_if.so  $(DESTDIR)$(libdir)
-	install -m 0755 libpigpiod_if2.so $(DESTDIR)$(libdir)
-	install -m 0755 -d                $(DESTDIR)$(bindir)
-	install -m 0755 pig2vcd           $(DESTDIR)$(bindir)
-	install -m 0755 pigpiod           $(DESTDIR)$(bindir)
-	install -m 0755 pigs              $(DESTDIR)$(bindir)
+	install -m 0755 -d                             $(DESTDIR)/opt/pigpio/cgi
+	install -m 0755 -d                             $(DESTDIR)$(includedir)
+	install -m 0644 pigpio.h                       $(DESTDIR)$(includedir)
+	install -m 0644 pigpiod_if.h                   $(DESTDIR)$(includedir)
+	install -m 0644 pigpiod_if2.h                  $(DESTDIR)$(includedir)
+	install -m 0755 -d                             $(DESTDIR)$(libdir)
+	install -m 0755 libpigpio.so.$(SOVERSION)      $(DESTDIR)$(libdir)
+	install -m 0755 libpigpiod_if.so.$(SOVERSION)  $(DESTDIR)$(libdir)
+	install -m 0755 libpigpiod_if2.so.$(SOVERSION) $(DESTDIR)$(libdir)
+	cd $(DESTDIR)$(libdir) && ln -fs libpigpio.so.$(SOVERSION)      libpigpio.so
+	cd $(DESTDIR)$(libdir) && ln -fs libpigpiod_if.so.$(SOVERSION)  libpigpiod_if.so
+	cd $(DESTDIR)$(libdir) && ln -fs libpigpiod_if2.so.$(SOVERSION) libpigpiod_if2.so
+	install -m 0755 -d                             $(DESTDIR)$(bindir)
+	install -m 0755 pig2vcd                        $(DESTDIR)$(bindir)
+	install -m 0755 pigpiod                        $(DESTDIR)$(bindir)
+	install -m 0755 pigs                           $(DESTDIR)$(bindir)
 	if which python2; then python2 setup.py install; fi
 	if which python3; then python3 setup.py install; fi
-	install -m 0755 -d                $(DESTDIR)$(mandir)/man1
-	install -m 0644 *.1               $(DESTDIR)$(mandir)/man1
-	install -m 0755 -d                $(DESTDIR)$(mandir)/man3
-	install -m 0644 *.3               $(DESTDIR)$(mandir)/man3
+	install -m 0755 -d                             $(DESTDIR)$(mandir)/man1
+	install -m 0644 *.1                            $(DESTDIR)$(mandir)/man1
+	install -m 0755 -d                             $(DESTDIR)$(mandir)/man3
+	install -m 0644 *.3                            $(DESTDIR)$(mandir)/man3
+ifeq ($(DESTDIR),)
 	ldconfig
+endif
 
 uninstall:
 	rm -f $(DESTDIR)$(includedir)/pigpio.h
@@ -107,6 +114,9 @@ uninstall:
 	rm -f $(DESTDIR)$(libdir)/libpigpio.so
 	rm -f $(DESTDIR)$(libdir)/libpigpiod_if.so
 	rm -f $(DESTDIR)$(libdir)/libpigpiod_if2.so
+	rm -f $(DESTDIR)$(libdir)/libpigpio.so.$(SOVERSION)
+	rm -f $(DESTDIR)$(libdir)/libpigpiod_if.so.$(SOVERSION)
+	rm -f $(DESTDIR)$(libdir)/libpigpiod_if2.so.$(SOVERSION)
 	rm -f $(DESTDIR)$(bindir)/pig2vcd
 	rm -f $(DESTDIR)$(bindir)/pigpiod
 	rm -f $(DESTDIR)$(bindir)/pigs
@@ -117,17 +127,20 @@ uninstall:
 	ldconfig
 
 $(LIB1):	$(OBJ1)
-	$(SHLIB) -o $(LIB1) $(OBJ1)
+	$(SHLIB) -Wl,-soname,$(LIB1).$(SOVERSION) -o $(LIB1).$(SOVERSION) $(OBJ1)
+	ln -fs $(LIB1).$(SOVERSION) $(LIB1)
 	$(STRIPLIB) $(LIB1)
 	$(SIZE)     $(LIB1)
 
 $(LIB2):	$(OBJ2)
-	$(SHLIB) -o $(LIB2) $(OBJ2)
+	$(SHLIB) -Wl,-soname,$(LIB2).$(SOVERSION) -o $(LIB2).$(SOVERSION) $(OBJ2)
+	ln -fs $(LIB2).$(SOVERSION) $(LIB2)
 	$(STRIPLIB) $(LIB2)
 	$(SIZE)     $(LIB2)
 
 $(LIB3):	$(OBJ3)
-	$(SHLIB) -o $(LIB3) $(OBJ3)
+	$(SHLIB) -Wl,-soname,$(LIB3).$(SOVERSION) -o $(LIB3).$(SOVERSION) $(OBJ3)
+	ln -fs $(LIB3).$(SOVERSION) $(LIB3)
 	$(STRIPLIB) $(LIB3)
 	$(SIZE)     $(LIB3)
 

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,12 @@ pig2vcd:	pig2vcd.o
 clean:
 	rm -f *.o *.i *.s *~ $(ALL) *.so.$(SOVERSION)
 
+ifeq ($(DESTDIR),)
+  PYINSTALLARGS =
+else
+  PYINSTALLARGS = --root=$(DESTDIR)
+endif
+
 install:	$(ALL)
 	install -m 0755 -d                             $(DESTDIR)/opt/pigpio/cgi
 	install -m 0755 -d                             $(DESTDIR)$(includedir)
@@ -97,8 +103,8 @@ install:	$(ALL)
 	install -m 0755 pig2vcd                        $(DESTDIR)$(bindir)
 	install -m 0755 pigpiod                        $(DESTDIR)$(bindir)
 	install -m 0755 pigs                           $(DESTDIR)$(bindir)
-	if which python2; then python2 setup.py install; fi
-	if which python3; then python3 setup.py install; fi
+	if which python2; then python2 setup.py install $(PYINSTALLARGS); fi
+	if which python3; then python3 setup.py install $(PYINSTALLARGS); fi
 	install -m 0755 -d                             $(DESTDIR)$(mandir)/man1
 	install -m 0644 *.1                            $(DESTDIR)$(mandir)/man1
 	install -m 0755 -d                             $(DESTDIR)$(mandir)/man3
@@ -120,11 +126,13 @@ uninstall:
 	rm -f $(DESTDIR)$(bindir)/pig2vcd
 	rm -f $(DESTDIR)$(bindir)/pigpiod
 	rm -f $(DESTDIR)$(bindir)/pigs
-	if which python2; then python2 setup.py install --record /tmp/pigpio >/dev/null; xargs rm -f < /tmp/pigpio >/dev/null; fi
-	if which python3; then python3 setup.py install --record /tmp/pigpio >/dev/null; xargs rm -f < /tmp/pigpio >/dev/null; fi
+	if which python2; then python2 setup.py install $(PYINSTALLARGS) --record /tmp/pigpio >/dev/null; sed 's!^!$(DESTDIR)!' < /tmp/pigpio | xargs rm -f >/dev/null; fi
+	if which python3; then python3 setup.py install $(PYINSTALLARGS) --record /tmp/pigpio >/dev/null; sed 's!^!$(DESTDIR)!' < /tmp/pigpio | xargs rm -f >/dev/null; fi
 	rm -f $(DESTDIR)$(mandir)/man1/pig*.1
 	rm -f $(DESTDIR)$(mandir)/man3/pig*.3
+ifeq ($(DESTDIR),)
 	ldconfig
+endif
 
 $(LIB1):	$(OBJ1)
 	$(SHLIB) -Wl,-soname,$(LIB1).$(SOVERSION) -o $(LIB1).$(SOVERSION) $(OBJ1)


### PR DESCRIPTION
This pull request contains three commits.

The first adds soversions to the shared libraries to comply with normal practice on unix-like systems and more specifically with Debian policy on shared libraries. I have started the soversion with a version of 1 but if you prefer to use some other number for the soversion that is fine too.

The second fixes the DESTDIR parameter in the install and uninstall targets so that the also install/uninstall the python stuff from the DESTDIR

The third makes "make uninstall" remove the library man pages which were left behind before.
