### PR TITLE
Const correctness on char*

### DIFF
--- a/pigpio.3
+++ b/pigpio.3
@@ -1907,7 +1907,7 @@ else
 
 .EE
 
-.IP "\fBint gpioWaveAddSerial(unsigned user_gpio, unsigned baud, unsigned data_bits, unsigned stop_bits, unsigned offset, unsigned numBytes, char *str)\fP"
+.IP "\fBint gpioWaveAddSerial(unsigned user_gpio, unsigned baud, unsigned data_bits, unsigned stop_bits, unsigned offset, unsigned numBytes, const char *str)\fP"
 .IP "" 4
 This function adds a waveform representing serial data to the
 existing waveform (if any).  The serial data starts offset
@@ -2204,7 +2204,7 @@ wave_mode: PI_WAVE_MODE_ONE_SHOT, PI_WAVE_MODE_REPEAT,
 Returns the number of DMA control blocks in the waveform if OK,
 otherwise PI_BAD_WAVE_ID, or PI_BAD_WAVE_MODE.
 
-.IP "\fBint gpioWaveChain(char *buf, unsigned bufSize)\fP"
+.IP "\fBint gpioWaveChain(const char *buf, unsigned bufSize)\fP"
 .IP "" 4
 This function transmits a chain of waveforms.
 
@@ -2994,7 +2994,7 @@ S Addr Wr [A] i2cReg [A] wValLow [A] wValHigh [A]
 
 .EE
 
-.IP "\fBint i2cWriteBlockData(unsigned handle, unsigned i2cReg, char *buf, unsigned count)\fP"
+.IP "\fBint i2cWriteBlockData(unsigned handle, unsigned i2cReg, const char *buf, unsigned count)\fP"
 .IP "" 4
 This writes up to 32 bytes to the specified register of the device
 associated with handle.
@@ -3164,7 +3164,7 @@ S Addr Wr [A] i2cReg [A]
 
 .EE
 
-.IP "\fBint i2cWriteI2CBlockData(unsigned handle, unsigned i2cReg, char *buf, unsigned count)\fP"
+.IP "\fBint i2cWriteI2CBlockData(unsigned handle, unsigned i2cReg, const char *buf, unsigned count)\fP"
 .IP "" 4
 This writes 1 to 32 bytes to the specified register of the device
 associated with handle.
@@ -3235,7 +3235,7 @@ S Addr Rd [A] [buf0] A [buf1] A ... A [bufn] NA P
 
 .EE
 
-.IP "\fBint i2cWriteDevice(unsigned handle, char *buf, unsigned count)\fP"
+.IP "\fBint i2cWriteDevice(unsigned handle, const char *buf, unsigned count)\fP"
 .IP "" 4
 This writes count bytes from buf to the raw device.
 
@@ -3318,7 +3318,7 @@ numSegs: >0, the number of I2C segments
 .br
 Returns the number of segments if OK, otherwise PI_BAD_I2C_SEG.
 
-.IP "\fBint i2cZip(unsigned handle, char *inBuf, unsigned inLen, char *outBuf, unsigned outLen)\fP"
+.IP "\fBint i2cZip(unsigned handle, const char *inBuf, unsigned inLen, char *outBuf, unsigned outLen)\fP"
 .IP "" 4
 This function executes a sequence of I2C operations.  The
 operations to be performed are specified by the contents of inBuf
@@ -3497,7 +3497,7 @@ SDA: 0-31, the SDA GPIO used in a prior call to \fBbbI2COpen\fP
 .br
 Returns 0 if OK, otherwise PI_BAD_USER_GPIO, or PI_NOT_I2C_GPIO.
 
-.IP "\fBint bbI2CZip(unsigned SDA, char *inBuf, unsigned inLen, char *outBuf, unsigned outLen)\fP"
+.IP "\fBint bbI2CZip(unsigned SDA, const char *inBuf, unsigned inLen, char *outBuf, unsigned outLen)\fP"
 .IP "" 4
 This function executes a sequence of bit banged I2C operations.  The
 operations to be performed are specified by the contents of inBuf
@@ -4002,7 +4002,7 @@ CS: 0-31, the CS GPIO used in a prior call to \fBbbSPIOpen\fP
 .br
 Returns 0 if OK, otherwise PI_BAD_USER_GPIO, or PI_NOT_SPI_GPIO.
 
-.IP "\fBint bbSPIXfer(unsigned CS, char *inBuf, char *outBuf, unsigned count)\fP"
+.IP "\fBint bbSPIXfer(unsigned CS, const char *inBuf, char *outBuf, unsigned count)\fP"
 .IP "" 4
 This function executes a bit banged SPI transfer.
 
@@ -4397,7 +4397,7 @@ handle: >=0, as returned by a call to \fBspiOpen\fP
 Returns the number of bytes transferred if OK, otherwise
 PI_BAD_HANDLE, PI_BAD_SPI_COUNT, or PI_SPI_XFER_FAILED.
 
-.IP "\fBint spiWrite(unsigned handle, char *buf, unsigned count)\fP"
+.IP "\fBint spiWrite(unsigned handle, const char *buf, unsigned count)\fP"
 .IP "" 4
 This function writes count bytes of data from buf to the SPI
 device associated with the handle.
@@ -4422,7 +4422,7 @@ handle: >=0, as returned by a call to \fBspiOpen\fP
 Returns the number of bytes transferred if OK, otherwise
 PI_BAD_HANDLE, PI_BAD_SPI_COUNT, or PI_SPI_XFER_FAILED.
 
-.IP "\fBint spiXfer(unsigned handle, char *txBuf, char *rxBuf, unsigned count)\fP"
+.IP "\fBint spiXfer(unsigned handle, const char *txBuf, char *rxBuf, unsigned count)\fP"
 .IP "" 4
 This function transfers count bytes of data from txBuf to the SPI
 device associated with the handle.  Simultaneously count bytes of
@@ -4450,7 +4450,7 @@ handle: >=0, as returned by a call to \fBspiOpen\fP
 Returns the number of bytes transferred if OK, otherwise
 PI_BAD_HANDLE, PI_BAD_SPI_COUNT, or PI_SPI_XFER_FAILED.
 
-.IP "\fBint serOpen(char *sertty, unsigned baud, unsigned serFlags)\fP"
+.IP "\fBint serOpen(const char *sertty, unsigned baud, unsigned serFlags)\fP"
 .IP "" 4
 This function opens a serial device at a specified baud rate
 and with specified flags.  The device name must start with
@@ -4552,7 +4552,7 @@ PI_SER_READ_NO_DATA, or PI_SER_READ_FAILED.
 .br
 If no data is ready PI_SER_READ_NO_DATA is returned.
 
-.IP "\fBint serWrite(unsigned handle, char *buf, unsigned count)\fP"
+.IP "\fBint serWrite(unsigned handle, const char *buf, unsigned count)\fP"
 .IP "" 4
 This function writes count bytes from buf to the the serial port
 associated with handle.
@@ -6262,7 +6262,7 @@ The meaning of other events is arbitrary.
 Note that other than its id and its tick there is no data associated
 with an event.
 
-.IP "\fBint shell(char *scriptName, char *scriptString)\fP"
+.IP "\fBint shell(const char *scriptName, const char *scriptString)\fP"
 .IP "" 4
 This function uses the system call to execute a shell script
 with the given string as its parameter.
@@ -6346,7 +6346,7 @@ status = shell("scr1", "\"hello string with spaces world\"");
 
 .EE
 
-.IP "\fBint fileOpen(char *file, unsigned mode)\fP"
+.IP "\fBint fileOpen(const char *file, unsigned mode)\fP"
 .IP "" 4
 This function returns a handle to a file opened in a specified mode.
 
@@ -6600,7 +6600,7 @@ fileClose(h);
 
 .EE
 
-.IP "\fBint fileWrite(unsigned handle, char *buf, unsigned count)\fP"
+.IP "\fBint fileWrite(unsigned handle, const char *buf, unsigned count)\fP"
 .IP "" 4
 This function writes count bytes from buf to the the file
 associated with handle.
@@ -7324,7 +7324,7 @@ Returns >= 0 if OK, less than 0 indicates a user defined error.
 .br
 The number of returned bytes must be retMax or less.
 
-.IP "\fBint rawWaveAddSPI(rawSPI_t *spi, unsigned offset, unsigned spiSS, char *buf, unsigned spiTxBits, unsigned spiBitFirst, unsigned spiBitLast, unsigned spiBits)\fP"
+.IP "\fBint rawWaveAddSPI(rawSPI_t *spi, unsigned offset, unsigned spiSS, const char *buf, unsigned spiTxBits, unsigned spiBitFirst, unsigned spiBitLast, unsigned spiBits)\fP"
 .IP "" 4
 This function adds a waveform representing SPI data to the
 existing waveform (if any).
@@ -7602,7 +7602,7 @@ wave_id: the wave of interest
 .br
 Not intended for general use.
 
-.IP "\fBint getBitInBytes(int bitPos, char *buf, int numBits)\fP"
+.IP "\fBint getBitInBytes(int bitPos, const char *buf, int numBits)\fP"
 .IP "" 4
 Returns the value of the bit bitPos bits from the start of buf.  Returns
 0 if bitPos is greater than or equal to numBits.

--- a/pigpio.c
+++ b/pigpio.c
@@ -1490,7 +1490,7 @@ static void closeOrphanedNotifications(int slot, int fd);
 
 /* ======================================================================= */
 
-int myScriptNameValid(char *name)
+int myScriptNameValid(const char *name)
 {
    int i, c, len, valid;
 
@@ -1535,7 +1535,7 @@ static char * myTimeStamp()
 
 /* ----------------------------------------------------------------------- */
 
-int myPathBad(char *name)
+int myPathBad(const char *name)
 {
    int i, c, len, in_part, parts, last_char_dot;
    char *bad="/*?.";
@@ -1679,7 +1679,7 @@ static uint32_t myGpioDelay(uint32_t micros)
 
 /* ----------------------------------------------------------------------- */
 
-static void myCreatePipe(char * name, int perm)
+static void myCreatePipe(const char * name, int perm)
 {
    unlink(name);
 
@@ -1732,7 +1732,7 @@ static uint32_t myGetLevel(int pos)
 
 /* ----------------------------------------------------------------------- */
 
-static int myI2CGetPar(char *inBuf, int *inPos, int inLen, int *esc)
+static int myI2CGetPar(const char *inBuf, int *inPos, int inLen, int *esc)
 {
    int bytes;
 
@@ -2678,7 +2678,7 @@ static void myGpioSetServo(unsigned gpio, int oldVal, int newVal)
 https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface
 */
 
-static int mbCreate(char *dev)
+static int mbCreate(const char *dev)
 {
    /* <0 error */
 
@@ -3682,7 +3682,7 @@ int i2cReadBlockData(unsigned handle, unsigned reg, char *buf)
 
 
 int i2cWriteBlockData(
-   unsigned handle, unsigned reg, char *buf, unsigned count)
+   unsigned handle, unsigned reg, const char *buf, unsigned count)
 {
    union my_smbus_data data;
 
@@ -3835,7 +3835,7 @@ int i2cReadI2CBlockData(
 
 
 int i2cWriteI2CBlockData(
-   unsigned handle, unsigned reg, char *buf, unsigned count)
+   unsigned handle, unsigned reg, const char *buf, unsigned count)
 {
    union my_smbus_data data;
 
@@ -3881,7 +3881,7 @@ int i2cWriteI2CBlockData(
    return status;
 }
 
-int i2cWriteDevice(unsigned handle, char *buf, unsigned count)
+int i2cWriteDevice(unsigned handle, const char *buf, unsigned count)
 {
    int bytes;
 
@@ -4089,14 +4089,14 @@ int i2cSegments(unsigned handle, pi_i2c_msg_t *segs, unsigned numSegs)
 
 int i2cZip(
    unsigned handle,
-   char *inBuf, unsigned inLen, char *outBuf, unsigned outLen)
+   const char *inBuf, unsigned inLen, char *outBuf, unsigned outLen)
 {
    int numSegs, inPos, outPos, status, bytes, flags, addr;
    int esc, setesc;
    pi_i2c_msg_t segs[PI_I2C_RDRW_IOCTL_MAX_MSGS];
 
    DBG(DBG_USER, "handle=%d inBuf=%s outBuf=%08X len=%d",
-      handle, myBuf2Str(inLen, (char *)inBuf), (int)outBuf, outLen);
+      handle, myBuf2Str(inLen, (const char *)inBuf), (int)outBuf, outLen);
 
    CHECK_INITED;
 
@@ -4247,7 +4247,7 @@ int i2cZip(
 
 /*SPI */
 
-static uint32_t _spiTXBits(char *buf, int pos, int bitlen, int msbf)
+static uint32_t _spiTXBits(const char *buf, int pos, int bitlen, int msbf)
 {
    uint32_t bits=0;
 
@@ -4290,11 +4290,11 @@ static void spiACS(int channel, int on)
 }
 
 static void spiGoA(
-   unsigned speed,    /* bits per second */
-   uint32_t flags,    /* flags           */
-   char     *txBuf,   /* tx buffer       */
-   char     *rxBuf,   /* rx buffer       */
-   unsigned count)    /* number of bytes */
+   unsigned   speed,    /* bits per second */
+   uint32_t   flags,    /* flags           */
+   const char *txBuf,   /* tx buffer       */
+   char       *rxBuf,   /* rx buffer       */
+   unsigned   count)    /* number of bytes */
 {
    int cs;
    char bit_ir[4] = {1, 0, 0, 1}; /* read on rising edge */
@@ -4393,11 +4393,11 @@ static void spiGoA(
 }
 
 static void spiGoS(
-   unsigned speed,
-   uint32_t flags,
-   char     *txBuf,
-   char     *rxBuf,
-   unsigned count)
+   unsigned   speed,
+   uint32_t   flags,
+   const char *txBuf,
+   char       *rxBuf,
+   unsigned   count)
 {
    unsigned txCnt=0;
    unsigned rxCnt=0;
@@ -4497,11 +4497,11 @@ static void spiGoS(
 }
 
 static void spiGo(
-   unsigned speed,
-   uint32_t flags,
-   char     *txBuf,
-   char     *rxBuf,
-   unsigned count)
+   unsigned   speed,
+   uint32_t   flags,
+   const char *txBuf,
+   char       *rxBuf,
+   unsigned   count)
 {
    static pthread_mutex_t main_mutex = PTHREAD_MUTEX_INITIALIZER;
    static pthread_mutex_t aux_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -4752,7 +4752,7 @@ int spiRead(unsigned handle, char *buf, unsigned count)
    return count;
 }
 
-int spiWrite(unsigned handle, char *buf, unsigned count)
+int spiWrite(unsigned handle, const char *buf, unsigned count)
 {
    DBG(DBG_USER, "handle=%d count=%d [%s]",
       handle, count, myBuf2Str(count, buf));
@@ -4773,7 +4773,7 @@ int spiWrite(unsigned handle, char *buf, unsigned count)
    return count;
 }
 
-int spiXfer(unsigned handle, char *txBuf, char *rxBuf, unsigned count)
+int spiXfer(unsigned handle, const char *txBuf, char *rxBuf, unsigned count)
 {
    DBG(DBG_USER, "handle=%d count=%d [%s]",
       handle, count, myBuf2Str(count, txBuf));
@@ -4797,7 +4797,7 @@ int spiXfer(unsigned handle, char *txBuf, char *rxBuf, unsigned count)
 /* ======================================================================= */
 
 
-int serOpen(char *tty, unsigned serBaud, unsigned serFlags)
+int serOpen(const char *tty, unsigned serBaud, unsigned serFlags)
 {
    static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
    struct termios new;
@@ -4961,7 +4961,7 @@ int serReadByte(unsigned handle)
       return PI_SER_READ_FAILED;
 }
 
-int serWrite(unsigned handle, char *buf, unsigned count)
+int serWrite(unsigned handle, const char *buf, unsigned count)
 {
    int written=0, wrote=0;
 
@@ -6488,7 +6488,7 @@ static int scrWait(gpioScript_t *s, uint32_t bits)
 
 /* ----------------------------------------------------------------------- */
 
-static int scrSys(char *cmd, uint32_t p1, uint32_t p2)
+static int scrSys(const char *cmd, uint32_t p1, uint32_t p2)
 {
    char buf[1024];
    int status;
@@ -7710,7 +7710,7 @@ static void initClock(int mainClock)
    const unsigned BITS=10;
    int clockPWM;
    unsigned clkCtl, clkDiv, clkSrc, clkDivI, clkDivF, clkMash, clkBits;
-   char *per;
+   const char *per;
    unsigned micros;
 
    DBG(DBG_STARTUP, "mainClock=%d", mainClock);
@@ -8072,7 +8072,7 @@ int initInitialise(void)
    int rev, i, model;
    struct sockaddr_in server;
    struct sockaddr_in6 server6;
-   char * portStr;
+   const char * portStr;
    unsigned port;
    struct sched_param param;
    pthread_attr_t pthAttr;
@@ -8255,7 +8255,7 @@ int initInitialise(void)
 
 /* ======================================================================= */
 
-int getBitInBytes(int bitPos, char *buf, int numBits)
+int getBitInBytes(int bitPos, const char *buf, int numBits)
 {
    int bitp, bufp;
 
@@ -9131,13 +9131,13 @@ int gpioWaveAddGeneric(unsigned numPulses, gpioPulse_t *pulses)
 /* ----------------------------------------------------------------------- */
 
 int gpioWaveAddSerial
-   (unsigned gpio,
-    unsigned baud,
-    unsigned data_bits,
-    unsigned stop_bits,
-    unsigned offset,
-    unsigned numBytes,
-    char     *bstr)
+   (unsigned   gpio,
+    unsigned   baud,
+    unsigned   data_bits,
+    unsigned   stop_bits,
+    unsigned   offset,
+    unsigned   numBytes,
+    const char *bstr)
 {
    int i, b, p, lev, c, v;
 
@@ -9265,14 +9265,14 @@ int gpioWaveAddSerial
 /* ----------------------------------------------------------------------- */
 
 int rawWaveAddSPI(
-   rawSPI_t *spi,
-   unsigned offset,
-   unsigned spiSS,
-   char *buf,
-   unsigned spiTxBits,
-   unsigned spiBitFirst,
-   unsigned spiBitLast,
-   unsigned spiBits)
+   rawSPI_t   *spi,
+   unsigned   offset,
+   unsigned   spiSS,
+   const char *buf,
+   unsigned   spiTxBits,
+   unsigned   spiBitFirst,
+   unsigned   spiBitLast,
+   unsigned   spiBits)
 {
    int p, bit, dbv, halfbit;
    int rising_edge[2], read_cycle[2];
@@ -9784,7 +9784,7 @@ static void chainMakeCounter(
 }
 
 
-int gpioWaveChain(char *buf, unsigned bufSize)
+int gpioWaveChain(const char *buf, unsigned bufSize)
 {
    unsigned blklen=16, blocks=4;
    int cb, chaincb;
@@ -10431,11 +10431,11 @@ int bbI2CClose(unsigned SDA)
 /*-------------------------------------------------------------------------*/
 
 int bbI2CZip(
-   unsigned SDA,
-   char *inBuf,
-   unsigned inLen,
-   char *outBuf,
-   unsigned outLen)
+   unsigned   SDA,
+   const char *inBuf,
+   unsigned   inLen,
+   char       *outBuf,
+   unsigned   outLen)
 {
    int i, ack, inPos, outPos, status, bytes;
    int addr, flags, esc, setesc;
@@ -10988,10 +10988,10 @@ int bbSPIClose(unsigned CS)
 /*-------------------------------------------------------------------------*/
 
 int bbSPIXfer(
-   unsigned CS,
-   char *inBuf,
-   char *outBuf,
-   unsigned count)
+   unsigned   CS,
+   const char *inBuf,
+   char       *outBuf,
+   unsigned   count)
 {
    int SCLK;
    int pos;
@@ -12780,7 +12780,7 @@ int gpioGetPad(unsigned pad)
    return strength;
 }
 
-int shell(char *scriptName, char *scriptString)
+int shell(const char *scriptName, const char *scriptString)
 {
    int status;
    char buf[4096];
@@ -12805,7 +12805,7 @@ int shell(char *scriptName, char *scriptString)
 }
 
 
-int fileApprove(char *filename)
+int fileApprove(const char *filename)
 {
    char match[PI_MAX_PATH];
    char buffer[PI_MAX_PATH];
@@ -12870,7 +12870,7 @@ int fileApprove(char *filename)
    return PI_FILE_NONE;
 }
 
-int fileOpen(char *file, unsigned mode)
+int fileOpen(const char *file, unsigned mode)
 {
    static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
    int fd=-1;
@@ -12988,7 +12988,7 @@ int fileClose(unsigned handle)
    return 0;
 }
 
-int fileWrite(unsigned handle, char *buf, unsigned count)
+int fileWrite(unsigned handle, const char *buf, unsigned count)
 {
    int w;
 

--- a/pigpio.c
+++ b/pigpio.c
@@ -1576,7 +1576,7 @@ int myPathBad(const char *name)
 
 /* ----------------------------------------------------------------------- */
 
-static char *myBuf2Str(unsigned count, char *buf)
+static char *myBuf2Str(unsigned count, const char *buf)
 {
    static char str[128];
    int i, c;

--- a/pigpio.h
+++ b/pigpio.h
@@ -1835,13 +1835,13 @@ D*/
 
 /*F*/
 int gpioWaveAddSerial
-   (unsigned user_gpio,
-    unsigned baud,
-    unsigned data_bits,
-    unsigned stop_bits,
-    unsigned offset,
-    unsigned numBytes,
-    char     *str);
+   (unsigned   user_gpio,
+    unsigned   baud,
+    unsigned   data_bits,
+    unsigned   stop_bits,
+    unsigned   offset,
+    unsigned   numBytes,
+    const char *str);
 /*D
 This function adds a waveform representing serial data to the
 existing waveform (if any).  The serial data starts offset
@@ -2001,7 +2001,7 @@ D*/
 
 
 /*F*/
-int gpioWaveChain(char *buf, unsigned bufSize);
+int gpioWaveChain(const char *buf, unsigned bufSize);
 /*D
 This function transmits a chain of waveforms.
 
@@ -2507,7 +2507,7 @@ D*/
 
 /*F*/
 int i2cWriteBlockData(
-unsigned handle, unsigned i2cReg, char *buf, unsigned count);
+unsigned handle, unsigned i2cReg, const char *buf, unsigned count);
 /*D
 This writes up to 32 bytes to the specified register of the device
 associated with handle.
@@ -2611,7 +2611,7 @@ D*/
 
 /*F*/
 int i2cWriteI2CBlockData(
-unsigned handle, unsigned i2cReg, char *buf, unsigned count);
+unsigned handle, unsigned i2cReg, const char *buf, unsigned count);
 /*D
 This writes 1 to 32 bytes to the specified register of the device
 associated with handle.
@@ -2652,7 +2652,7 @@ D*/
 
 
 /*F*/
-int i2cWriteDevice(unsigned handle, char *buf, unsigned count);
+int i2cWriteDevice(unsigned handle, const char *buf, unsigned count);
 /*D
 This writes count bytes from buf to the raw device.
 
@@ -2702,11 +2702,11 @@ D*/
 
 /*F*/
 int i2cZip(
-   unsigned handle,
-   char    *inBuf,
-   unsigned inLen,
-   char    *outBuf,
-   unsigned outLen);
+   unsigned    handle,
+   const char *inBuf,
+   unsigned    inLen,
+   char       *outBuf,
+   unsigned    outLen);
 /*D
 This function executes a sequence of I2C operations.  The
 operations to be performed are specified by the contents of inBuf
@@ -2804,11 +2804,11 @@ D*/
 
 /*F*/
 int bbI2CZip(
-   unsigned SDA,
-   char    *inBuf,
-   unsigned inLen,
-   char    *outBuf,
-   unsigned outLen);
+   unsigned    SDA,
+   const char *inBuf,
+   unsigned    inLen,
+   char       *outBuf,
+   unsigned    outLen);
 /*D
 This function executes a sequence of bit banged I2C operations.  The
 operations to be performed are specified by the contents of inBuf
@@ -3065,10 +3065,10 @@ D*/
 
 /*F*/
 int bbSPIXfer(
-   unsigned CS,
-   char    *inBuf,
-   char    *outBuf,
-   unsigned count);
+   unsigned    CS,
+   const char *inBuf,
+   char       *outBuf,
+   unsigned    count);
 /*D
 This function executes a bit banged SPI transfer.
 
@@ -3272,7 +3272,7 @@ D*/
 
 
 /*F*/
-int spiWrite(unsigned handle, char *buf, unsigned count);
+int spiWrite(unsigned handle, const char *buf, unsigned count);
 /*D
 This function writes count bytes of data from buf to the SPI
 device associated with the handle.
@@ -3288,7 +3288,7 @@ PI_BAD_HANDLE, PI_BAD_SPI_COUNT, or PI_SPI_XFER_FAILED.
 D*/
 
 /*F*/
-int spiXfer(unsigned handle, char *txBuf, char *rxBuf, unsigned count);
+int spiXfer(unsigned handle, const char *txBuf, char *rxBuf, unsigned count);
 /*D
 This function transfers count bytes of data from txBuf to the SPI
 device associated with the handle.  Simultaneously count bytes of
@@ -3307,7 +3307,7 @@ D*/
 
 
 /*F*/
-int serOpen(char *sertty, unsigned baud, unsigned serFlags);
+int serOpen(const char *sertty, unsigned baud, unsigned serFlags);
 /*D
 This function opens a serial device at a specified baud rate
 and with specified flags.  The device name must start with
@@ -3371,7 +3371,7 @@ If no data is ready PI_SER_READ_NO_DATA is returned.
 D*/
 
 /*F*/
-int serWrite(unsigned handle, char *buf, unsigned count);
+int serWrite(unsigned handle, const char *buf, unsigned count);
 /*D
 This function writes count bytes from buf to the the serial port
 associated with handle.
@@ -4351,7 +4351,7 @@ D*/
 
 
 /*F*/
-int shell(char *scriptName, char *scriptString);
+int shell(const char *scriptName, const char *scriptString);
 /*D
 This function uses the system call to execute a shell script
 with the given string as its parameter.
@@ -4397,7 +4397,7 @@ D*/
 #pragma GCC diagnostic ignored "-Wcomment"
 
 /*F*/
-int fileOpen(char *file, unsigned mode);
+int fileOpen(const char *file, unsigned mode);
 /*D
 This function returns a handle to a file opened in a specified mode.
 
@@ -4522,7 +4522,7 @@ D*/
 
 
 /*F*/
-int fileWrite(unsigned handle, char *buf, unsigned count);
+int fileWrite(unsigned handle, const char *buf, unsigned count);
 /*D
 This function writes count bytes from buf to the the file
 associated with handle.
@@ -4603,7 +4603,7 @@ D*/
 #pragma GCC diagnostic ignored "-Wcomment"
 
 /*F*/
-int fileList(char *fpat,  char *buf, unsigned count);
+int fileList(char *fpat, char *buf, unsigned count);
 /*D
 This function returns a list of files which match a pattern.  The
 pattern may contain wildcards.
@@ -4948,14 +4948,14 @@ D*/
 
 /*F*/
 int rawWaveAddSPI(
-   rawSPI_t *spi,
-   unsigned offset,
-   unsigned spiSS,
-   char *buf,
-   unsigned spiTxBits,
-   unsigned spiBitFirst,
-   unsigned spiBitLast,
-   unsigned spiBits);
+   rawSPI_t    *spi,
+   unsigned    offset,
+   unsigned    spiSS,
+   const char *buf,
+   unsigned    spiTxBits,
+   unsigned    spiBitFirst,
+   unsigned    spiBitLast,
+   unsigned    spiBits);
 /*D
 This function adds a waveform representing SPI data to the
 existing waveform (if any).
@@ -5124,7 +5124,7 @@ Not intended for general use.
 D*/
 
 /*F*/
-int getBitInBytes(int bitPos, char *buf, int numBits);
+int getBitInBytes(int bitPos, const char *buf, int numBits);
 /*D
 Returns the value of the bit bitPos bits from the start of buf.  Returns
 0 if bitPos is greater than or equal to numBits.


### PR DESCRIPTION
Mechanically converts char* types to const char* types in pigpio.c and pigpio.h when correct.
Emphasis on the API accepting const char* where appropriate.