### PR TITLE
Pi detection and 64-bit cleanliness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,19 +136,19 @@ ifeq ($(DESTDIR),)
 endif
 
 $(LIB1):	$(OBJ1)
-	$(SHLIB) -Wl,-soname,$(LIB1).$(SOVERSION) -o $(LIB1).$(SOVERSION) $(OBJ1)
+	$(SHLIB) -pthread -Wl,-soname,$(LIB1).$(SOVERSION) -o $(LIB1).$(SOVERSION) $(OBJ1)
 	ln -fs $(LIB1).$(SOVERSION) $(LIB1)
 	$(STRIPLIB) $(LIB1)
 	$(SIZE)     $(LIB1)
 
 $(LIB2):	$(OBJ2)
-	$(SHLIB) -Wl,-soname,$(LIB2).$(SOVERSION) -o $(LIB2).$(SOVERSION) $(OBJ2)
+	$(SHLIB) -pthread -Wl,-soname,$(LIB2).$(SOVERSION) -o $(LIB2).$(SOVERSION) $(OBJ2)
 	ln -fs $(LIB2).$(SOVERSION) $(LIB2)
 	$(STRIPLIB) $(LIB2)
 	$(SIZE)     $(LIB2)
 
 $(LIB3):	$(OBJ3)
-	$(SHLIB) -Wl,-soname,$(LIB3).$(SOVERSION) -o $(LIB3).$(SOVERSION) $(OBJ3)
+	$(SHLIB) -pthread -Wl,-soname,$(LIB3).$(SOVERSION) -o $(LIB3).$(SOVERSION) $(OBJ3)
 	ln -fs $(LIB3).$(SOVERSION) $(LIB3)
 	$(STRIPLIB) $(LIB3)
 	$(SIZE)     $(LIB3)

--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,9 @@ install:	$(ALL)
 	if which python2; then python2 setup.py install $(PYINSTALLARGS); fi
 	if which python3; then python3 setup.py install $(PYINSTALLARGS); fi
 	install -m 0755 -d                             $(DESTDIR)$(mandir)/man1
-	install -m 0644 *.1                            $(DESTDIR)$(mandir)/man1
+	install -m 0644 p*.1                           $(DESTDIR)$(mandir)/man1
 	install -m 0755 -d                             $(DESTDIR)$(mandir)/man3
-	install -m 0644 *.3                            $(DESTDIR)$(mandir)/man3
+	install -m 0644 p*.3                           $(DESTDIR)$(mandir)/man3
 ifeq ($(DESTDIR),)
 	ldconfig
 endif

--- a/command.c
+++ b/command.c
@@ -34,6 +34,7 @@ This version is for pigpio version 67+
 #include <stdarg.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <inttypes.h>
 
 #include "pigpio.h"
 #include "command.h"
@@ -580,7 +581,7 @@ static int cmdMatch(char *str)
    return CMD_UNKNOWN_CMD;
 }
 
-static int getNum(char *str, uint32_t *val, int8_t *opt)
+static int getNum(char *str, uintptr_t *val, int8_t *opt)
 {
    int f, n;
    intmax_t v;
@@ -627,13 +628,13 @@ char *cmdStr(void)
 }
 
 int cmdParse(
-   char *buf, uint32_t *p, unsigned ext_len, char *ext, cmdCtlParse_t *ctl)
+   char *buf, uintptr_t *p, unsigned ext_len, char *ext, cmdCtlParse_t *ctl)
 {
    int f, valid, idx, val, pp, pars, n, n2;
    char *p8;
    int32_t *p32;
    char c;
-   uint32_t tp1=0, tp2=0, tp3=0, tp4=0, tp5=0;
+   uintptr_t tp1=0, tp2=0, tp3=0, tp4=0, tp5=0;
    int8_t to1, to2, to3, to4, to5;
    int eaten;
 
@@ -1260,7 +1261,7 @@ int cmdParseScript(char *script, cmdScript_t *s, int diags)
 {
    int idx, len, b, i, j, tags, resolved;
    int status;
-   uint32_t p[10];
+   uintptr_t p[10];
    cmdInstr_t instr;
    cmdCtlParse_t ctl;
    char v[CMD_MAX_EXTENSION];
@@ -1324,7 +1325,7 @@ int cmdParseScript(char *script, cmdScript_t *s, int diags)
                   {
                      if (diags)
                      {
-                        fprintf(stderr, "Duplicate tag: %d\n", instr.p[1]);
+                        fprintf(stderr, "Duplicate tag: %"PRIdPTR"\n", instr.p[1]);
                      }
 
                      if (!status) status = PI_DUP_TAG;
@@ -1340,7 +1341,7 @@ int cmdParseScript(char *script, cmdScript_t *s, int diags)
             {
                if (diags)
                {
-                  fprintf(stderr, "Too many tags: %d\n", instr.p[1]);
+                  fprintf(stderr, "Too many tags: %"PRIdPTR"\n", instr.p[1]);
                }
                if (!status) status = PI_TOO_MANY_TAGS;
                idx = -1;
@@ -1395,7 +1396,7 @@ int cmdParseScript(char *script, cmdScript_t *s, int diags)
          {
             if (diags)
             {
-               fprintf(stderr, "Can't resolve tag %d\n", instr.p[1]);
+               fprintf(stderr, "Can't resolve tag %"PRIdPTR"\n", instr.p[1]);
             }
             if (!status) status = PI_BAD_TAG;
          }

--- a/command.h
+++ b/command.h
@@ -86,7 +86,7 @@ typedef struct
 
 typedef struct
 {
-   uint32_t p[5];
+   uintptr_t p[5]; //these are sometimes converted to pointers, so presumablly they sometimes have pointers stored in them, I haven't figured out where though. --plugwash
    int8_t opt[4];
 } cmdInstr_t;
 
@@ -110,7 +110,7 @@ extern cmdInfo_t cmdInfo[];
 
 extern char *cmdUsage;
 
-int cmdParse(char *buf, uint32_t *p, unsigned ext_len, char *ext, cmdCtlParse_t *ctl);
+int cmdParse(char *buf, uintptr_t *p, unsigned ext_len, char *ext, cmdCtlParse_t *ctl);
 
 int cmdParseScript(char *script, cmdScript_t *s, int diags);
 

--- a/pigpio.c
+++ b/pigpio.c
@@ -36,6 +36,7 @@ For more information, please refer to <http://unlicense.org/>
 #include <strings.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <inttypes.h>
 #include <stdarg.h>
 #include <ctype.h>
 #include <syslog.h>
@@ -1831,7 +1832,7 @@ static void spinWhileStarting(void)
 
 /* ----------------------------------------------------------------------- */
 
-static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
+static int myDoCommand(uintptr_t *p, unsigned bufSize, char *buf)
 {
    int res, i, j;
    uint32_t mask;
@@ -1851,7 +1852,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          if ((mask | p[1]) != mask)
          {
             DBG(DBG_USER,
-               "gpioWrite_Bits_0_31_Clear: bad bits %08X (permissions %08X)",
+               "gpioWrite_Bits_0_31_Clear: bad bits %08"PRIXPTR" (permissions %08X)",
                p[1], mask);
             res = PI_SOME_PERMITTED;
          }
@@ -1865,7 +1866,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          if ((mask | p[1]) != mask)
          {
             DBG(DBG_USER,
-               "gpioWrite_Bits_32_53_Clear: bad bits %08X (permissions %08X)",
+               "gpioWrite_Bits_32_53_Clear: bad bits %08"PRIXPTR" (permissions %08X)",
                p[1], mask);
             res = PI_SOME_PERMITTED;
          }
@@ -1915,7 +1916,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          if (!myPermit(p[1]))
          {
             DBG(DBG_USER,
-               "bbSPIOpen: gpio %d, no permission to update CS", p[1]);
+               "bbSPIOpen: gpio %"PRIdPTR", no permission to update CS", p[1]);
             res = PI_NOT_PERMITTED;
          }
 
@@ -1964,7 +1965,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          if ((mask | p[1]) != mask)
          {
             DBG(DBG_USER,
-               "gpioWrite_Bits_0_31_Set: bad bits %08X (permissions %08X)",
+               "gpioWrite_Bits_0_31_Set: bad bits %08"PRIXPTR" (permissions %08X)",
                p[1], mask);
             res = PI_SOME_PERMITTED;
          }
@@ -1978,7 +1979,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          if ((mask | p[1]) != mask)
          {
             DBG(DBG_USER,
-               "gpioWrite_Bits_32_53_Set: bad bits %08X (permissions %08X)",
+               "gpioWrite_Bits_32_53_Set: bad bits %08"PRIXPTR" (permissions %08X)",
                p[1], mask);
             res = PI_SOME_PERMITTED;
          }
@@ -2043,7 +2044,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          else
          {
             DBG(DBG_USER,
-               "gpioHardwareClock: gpio %d, no permission to update",
+               "gpioHardwareClock: gpio %"PRIdPTR", no permission to update",
                 p[1] & 0xFFFFFF);
             res = PI_NOT_PERMITTED;
          }
@@ -2060,7 +2061,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          else
          {
             DBG(DBG_USER,
-               "gpioHardwarePWM: gpio %d, no permission to update", p[1]);
+               "gpioHardwarePWM: gpio %"PRIdPTR", no permission to update", p[1]);
             res = PI_NOT_PERMITTED;
          }
          break;
@@ -2158,7 +2159,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          else
          {
             DBG(DBG_USER,
-               "gpioSetMode: gpio %d, no permission to update", p[1]);
+               "gpioSetMode: gpio %"PRIdPTR", no permission to update", p[1]);
             res = PI_NOT_PERMITTED;
          }
          break;
@@ -2182,7 +2183,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          else
          {
             DBG(DBG_USER,
-               "gpioSetPWMfrequency: gpio %d, no permission to update", p[1]);
+               "gpioSetPWMfrequency: gpio %"PRIdPTR", no permission to update", p[1]);
             res = PI_NOT_PERMITTED;
          }
          break;
@@ -2218,7 +2219,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          else
          {
             DBG(DBG_USER,
-               "gpioSetPWMrange: gpio %d, no permission to update", p[1]);
+               "gpioSetPWMrange: gpio %"PRIdPTR", no permission to update", p[1]);
             res = PI_NOT_PERMITTED;
          }
          break;
@@ -2228,7 +2229,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          else
          {
             DBG(DBG_USER,
-               "gpioSetPullUpDown: gpio %d, no permission to update", p[1]);
+               "gpioSetPullUpDown: gpio %"PRIdPTR", no permission to update", p[1]);
             res = PI_NOT_PERMITTED;
          }
          break;
@@ -2237,7 +2238,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          if (myPermit(p[1])) res = gpioPWM(p[1], p[2]);
          else
          {
-            DBG(DBG_USER, "gpioPWM: gpio %d, no permission to update", p[1]);
+            DBG(DBG_USER, "gpioPWM: gpio %"PRIdPTR", no permission to update", p[1]);
             res = PI_NOT_PERMITTED;
          }
          break;
@@ -2249,7 +2250,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          else
          {
             DBG(DBG_USER,
-               "gpioServo: gpio %d, no permission to update", p[1]);
+               "gpioServo: gpio %"PRIdPTR", no permission to update", p[1]);
             res = PI_NOT_PERMITTED;
          }
          break;
@@ -2327,7 +2328,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          else
          {
             DBG(DBG_USER,
-               "gpioTrigger: gpio %d, no permission to update", p[1]);
+               "gpioTrigger: gpio %"PRIdPTR", no permission to update", p[1]);
             res = PI_NOT_PERMITTED;
          }
          break;
@@ -2338,7 +2339,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          if (myPermit(p[1])) res = gpioWrite(p[1], p[2]);
          else
          {
-            DBG(DBG_USER, "gpioWrite: gpio %d, no permission to update", p[1]);
+            DBG(DBG_USER, "gpioWrite: gpio %"PRIdPTR", no permission to update", p[1]);
             res = PI_NOT_PERMITTED;
          }
          break;
@@ -2393,7 +2394,7 @@ static int myDoCommand(uint32_t *p, unsigned bufSize, char *buf)
          {
             DBG(
                DBG_USER,
-               "gpioWaveAddSerial: gpio %d, no permission to update", p[1]);
+               "gpioWaveAddSerial: gpio %"PRIdPTR", no permission to update", p[1]);
             res = PI_NOT_PERMITTED;
          }
          break;
@@ -2857,7 +2858,9 @@ static uint32_t waveCbPOadr(int pos)
    page = pos/CBS_PER_OPAGE;
    slot = pos%CBS_PER_OPAGE;
 
-   return (uint32_t) &dmaOBus[page]->cb[slot];
+   //cast twice to suppress compiler warning, I belive this cast is ok
+   //because dmaOBus contains bus addresses, not virtual addresses.
+   return (uint32_t)(uintptr_t) &dmaOBus[page]->cb[slot];
 }
 
 /* ----------------------------------------------------------------------- */
@@ -2888,7 +2891,9 @@ static uint32_t waveOOLPOadr(int pos)
 
    waveOOLPageSlot(pos, &page, &slot);
 
-   return (uint32_t) &dmaOBus[page]->OOL[slot];
+   //cast twice to suppress compiler warning, I belive this cast is ok
+   //because dmaOBus contains bus addresses, not virtual addresses.
+   return (uint32_t)(uintptr_t) &dmaOBus[page]->OOL[slot];
 }
 
 
@@ -3002,7 +3007,9 @@ static int wave2Cbs(unsigned wave_mode, int *CB, int *BOOL, int *TOOL)
       p->dst  = PWM_TIMER;
    }
 
-   p->src    = (uint32_t) (&dmaOBus[0]->periphData);
+   //cast twice to suppress compiler warning, I belive this cast is ok
+   //because dmaOBus contains bus addresses, not virtual addresses.
+   p->src    = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
    p->length = BPD * 20 / PI_WF_MICROS; /* 20 micros delay */
    p->next   = waveCbPOadr(botCB);
 
@@ -3081,7 +3088,9 @@ static int wave2Cbs(unsigned wave_mode, int *CB, int *BOOL, int *TOOL)
                p->dst  = PWM_TIMER;
             }
 
-            p->src = (uint32_t) (&dmaOBus[0]->periphData);
+            //cast twice to suppress compiler warning, I belive this cast is ok
+            //because dmaOBus contains bus addresses, not virtual addresses.
+            p->src = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
 
             p->length = BPD * delayLeft / PI_WF_MICROS;
 
@@ -3642,7 +3651,7 @@ int i2cReadBlockData(unsigned handle, unsigned reg, char *buf)
 
    int i, status;
 
-   DBG(DBG_USER, "handle=%d reg=%d buf=%08X", handle, reg, (unsigned)buf);
+   DBG(DBG_USER, "handle=%d reg=%d buf=%08"PRIXPTR, handle, reg, (uintptr_t)buf);
 
    CHECK_INITED;
 
@@ -3788,8 +3797,8 @@ int i2cReadI2CBlockData(
    int i, status;
    uint32_t size;
 
-   DBG(DBG_USER, "handle=%d reg=%d count=%d buf=%08X",
-      handle, reg, count, (unsigned)buf);
+   DBG(DBG_USER, "handle=%d reg=%d count=%d buf=%08"PRIXPTR,
+      handle, reg, count, (uintptr_t)buf);
 
    CHECK_INITED;
 
@@ -3915,8 +3924,8 @@ int i2cReadDevice(unsigned handle, char *buf, unsigned count)
 {
    int bytes;
 
-   DBG(DBG_USER, "handle=%d count=%d buf=%08X",
-      handle, count, (unsigned)buf);
+   DBG(DBG_USER, "handle=%d count=%d buf=%08"PRIXPTR,
+      handle, count, (uintptr_t)buf);
 
    CHECK_INITED;
 
@@ -4096,8 +4105,8 @@ int i2cZip(
    int esc, setesc;
    pi_i2c_msg_t segs[PI_I2C_RDRW_IOCTL_MAX_MSGS];
 
-   DBG(DBG_USER, "handle=%d inBuf=%s outBuf=%08X len=%d",
-      handle, myBuf2Str(inLen, (char *)inBuf), (int)outBuf, outLen);
+   DBG(DBG_USER, "handle=%d inBuf=%s outBuf=%08"PRIXPTR" len=%d",
+      handle, myBuf2Str(inLen, (char *)inBuf), (uintptr_t)outBuf, outLen);
 
    CHECK_INITED;
 
@@ -5002,7 +5011,7 @@ int serRead(unsigned handle, char *buf, unsigned count)
 {
    int r;
 
-   DBG(DBG_USER, "handle=%d count=%d buf=0x%X", handle, count, (unsigned)buf);
+   DBG(DBG_USER, "handle=%d count=%d buf=0x%"PRIXPTR, handle, count, (uintptr_t)buf);
 
    SER_CHECK_INITED;
 
@@ -5157,7 +5166,9 @@ static unsigned dmaNowAtICB(void)
 
    while (1)
    {
-      cb = (cbAddr - ((int)dmaIBus[page])) / 32;
+      //cast twice to suppress compiler warning, I belive this cast is ok
+      //because dmaIbus contains bus addresses, not user addresses. --plugwash
+      cb = (cbAddr - ((int)(uintptr_t)dmaIBus[page])) / 32;
 
       if (cb < CBS_PER_IPAGE)
       {
@@ -5199,7 +5210,9 @@ static int dmaNowAtOCB(void)
 
    while (1)
    {
-      cb = (cbAddr - ((int)dmaOBus[page])) / 32;
+      //cast twice to suppress compiler warning, I belive this cast is ok
+      //because dmaIbus contains bus addresses, not user addresses. --plugwash
+      cb = (cbAddr - ((int)(uintptr_t)dmaOBus[page])) / 32;
 
       if (cb < CBS_PER_OPAGE) return (page*CBS_PER_OPAGE) + cb;
 
@@ -5218,7 +5231,9 @@ static int dmaNowAtOCB(void)
 
    while (1)
    {
-      cb = (cbAddr - ((int)dmaOBus[page])) / 32;
+      //cast twice to suppress compiler warning, I belive this cast is ok
+      //because dmaIbus contains bus addresses, not user addresses. --plugwash
+      cb = (cbAddr - ((int)(uintptr_t)dmaOBus[page])) / 32;
 
       if (cb < CBS_PER_OPAGE) return (page*CBS_PER_OPAGE) + cb;
 
@@ -5247,7 +5262,9 @@ unsigned rawWaveCB(void)
 
    while (1)
    {
-      cb = (cbAddr - ((int)dmaOBus[page])) / 32;
+      //cast twice to suppress compiler warning, I belive this cast is ok
+      //because dmaIbus contains bus addresses, not user addresses. --plugwash
+      cb = (cbAddr - ((int)(uintptr_t)dmaOBus[page])) / 32;
 
       if (cb < CBS_PER_OPAGE)
       {
@@ -5282,7 +5299,9 @@ static unsigned dmaCurrentSlot(unsigned pos)
 
 static uint32_t dmaPwmDataAdr(int pos)
 {
-   return (uint32_t) &dmaIBus[pos]->periphData;
+   //cast twice to suppress compiler warning, I belive this cast is ok
+   //because dmaIbus contains bus addresses, not user addresses. --plugwash
+   return (uint32_t)(uintptr_t) &dmaIBus[pos]->periphData;
 }
 
 /* ----------------------------------------------------------------------- */
@@ -5294,7 +5313,9 @@ static uint32_t dmaGpioOnAdr(int pos)
    page = pos/ON_PER_IPAGE;
    slot = pos%ON_PER_IPAGE;
 
-   return (uint32_t) &dmaIBus[page]->gpioOn[slot];
+   //cast twice to suppress compiler warning, I belive this cast is ok
+   //because dmaIbus contains bus addresses, not user addresses. --plugwash
+   return (uint32_t)(uintptr_t) &dmaIBus[page]->gpioOn[slot];
 }
 
 /* ----------------------------------------------------------------------- */
@@ -5305,7 +5326,9 @@ static uint32_t dmaGpioOffAdr(int pos)
 
    myOffPageSlot(pos, &page, &slot);
 
-   return (uint32_t) &dmaIBus[page]->gpioOff[slot];
+   //cast twice to suppress compiler warning, I belive this cast is ok
+   //because dmaIbus contains bus addresses, not user addresses. --plugwash
+   return (uint32_t)(uintptr_t) &dmaIBus[page]->gpioOff[slot];
 }
 
 /* ----------------------------------------------------------------------- */
@@ -5316,7 +5339,9 @@ static uint32_t dmaTickAdr(int pos)
 
    myTckPageSlot(pos, &page, &slot);
 
-   return (uint32_t) &dmaIBus[page]->tick[slot];
+   //cast twice to suppress compiler warning, I belive this cast is ok
+   //because dmaIbus contains bus addresses, not user addresses. --plugwash
+   return (uint32_t)(uintptr_t) &dmaIBus[page]->tick[slot];
 }
 
 /* ----------------------------------------------------------------------- */
@@ -5327,7 +5352,9 @@ static uint32_t dmaReadLevelsAdr(int pos)
 
    myLvsPageSlot(pos, &page, &slot);
 
-   return (uint32_t) &dmaIBus[page]->level[slot];
+   //cast twice to suppress compiler warning, I belive this cast is ok
+   //because dmaIbus contains bus addresses, not user addresses. --plugwash
+   return (uint32_t)(uintptr_t) &dmaIBus[page]->level[slot];
 }
 
 /* ----------------------------------------------------------------------- */
@@ -5339,7 +5366,9 @@ static uint32_t dmaCbAdr(int pos)
    page = (pos/CBS_PER_IPAGE);
    slot = (pos%CBS_PER_IPAGE);
 
-   return (uint32_t) &dmaIBus[page]->cb[slot];
+   //cast twice to suppress compiler warning, I belive this cast is ok
+   //because dmaIbus contains bus addresses, not user addresses. --plugwash
+   return (uint32_t)(uintptr_t) &dmaIBus[page]->cb[slot];
 }
 
 /* ----------------------------------------------------------------------- */
@@ -5467,7 +5496,7 @@ static void dmaInitCbs(void)
 
    p->next = dmaCbAdr(0);
 
-   DBG(DBG_STARTUP, "DMA page type count = %d", sizeof(dmaIPage_t));
+   DBG(DBG_STARTUP, "DMA page type count = %zd", sizeof(dmaIPage_t));
 
    DBG(DBG_STARTUP, "%d control blocks (exp=%d)", b+1, NUM_CBS);
 }
@@ -6022,7 +6051,7 @@ static void alertEmit(
                      else
                      {
                         gpioStats.shortPipeWrite++;
-                        DBG(DBG_ALWAYS, "emitted %d, asked for %d",
+                        DBG(DBG_ALWAYS, "emitted %zd, asked for %d",
                            err/sizeof(gpioReport_t), max_emits);
                      }
                   }
@@ -6062,7 +6091,7 @@ static void alertEmit(
                      else
                      {
                         gpioStats.shortPipeWrite++;
-                        DBG(DBG_ALWAYS, "emitted %d, asked for %d",
+                        DBG(DBG_ALWAYS, "emitted %zd, asked for %d",
                            err/sizeof(gpioReport_t), emit);
                      }
                   }
@@ -6229,7 +6258,9 @@ static void * pthAlertThread(void *x)
 
             dmaInitCbs();
             flushMemory();
-            initDMAgo((uint32_t *)dmaIn, (uint32_t)dmaIBus[0]);
+            //cast twice to suppress compiler warning, I belive this cast is ok
+            //because dmaIbus contains bus addresses, not user addresses. --plugwash
+            initDMAgo((uint32_t *)dmaIn, (uint32_t)(uintptr_t)dmaIBus[0]);
             myGpioDelay(5000); /* let DMA run for a while */
             oldSlot = dmaCurrentSlot(dmaNowAtICB());
             gpioStats.DMARestarts++;
@@ -6782,7 +6813,7 @@ static void * pthFifoThread(void *x)
 {
    char buf[CMD_MAX_EXTENSION];
    int idx, flags, len, res, i;
-   uint32_t p[CMD_P_ARR];
+   uintptr_t p[CMD_P_ARR];
    cmdCtlParse_t ctl;
    uint32_t *param;
    char v[CMD_MAX_EXTENSION];
@@ -6899,7 +6930,7 @@ static void * pthFifoThread(void *x)
 static void *pthSocketThreadHandler(void *fdC)
 {
    int sock = *(int*)fdC;
-   uint32_t p[10];
+   uintptr_t p[10];
    int opt;
    char buf[CMD_MAX_EXTENSION];
 
@@ -6922,7 +6953,7 @@ static void *pthSocketThreadHandler(void *fdC)
             {
                /* Serious error.  No point continuing. */
                DBG(DBG_ALWAYS,
-                  "recv failed for %d bytes, sock=%d", p[3], sock);
+                  "recv failed for %"PRIdPTR" bytes, sock=%d", p[3], sock);
 
                closeOrphanedNotifications(-1, sock);
 
@@ -6935,7 +6966,7 @@ static void *pthSocketThreadHandler(void *fdC)
          {
             /* Serious error.  No point continuing. */
             DBG(DBG_ALWAYS,
-               "ext too large %d(%d), sock=%d", p[3], sizeof(buf), sock);
+               "ext too large %"PRIdPTR"(%zd), sock=%d", p[3], sizeof(buf), sock);
 
             closeOrphanedNotifications(-1, sock);
 
@@ -7255,8 +7286,8 @@ static int initPeripherals(void)
       dmaOut = dmaReg + (gpioCfg.DMAsecondaryChannel * 0x40);
    }
 
-   DBG(DBG_STARTUP, "DMA #%d @ %08X @ %08X",
-      gpioCfg.DMAprimaryChannel, dmaBase, (uint32_t)dmaIn);
+   DBG(DBG_STARTUP, "DMA #%d @ %08X @ %08"PRIXPTR,
+      gpioCfg.DMAprimaryChannel, dmaBase, (uintptr_t)dmaIn);
 
    DBG(DBG_STARTUP, "debug reg is %08X", dmaIn[DMA_DEBUG]);
 
@@ -7309,21 +7340,21 @@ static int initZaps
    (int  pmapFd, void *virtualBase, int  basePage, int  pages)
 {
    int n;
-   long index;
+   uintptr_t index;
    off_t offset;
    ssize_t t;
    uint32_t physical;
    int status;
-   uint32_t pageAdr;
+   uintptr_t pageAdr;
    unsigned long long pa;
 
    DBG(DBG_STARTUP, "");
 
    status = 0;
 
-   pageAdr = (uint32_t) dmaVirt[basePage];
+   pageAdr = (uintptr_t) dmaVirt[basePage];
 
-   index  = ((uint32_t)virtualBase / PAGE_SIZE) * 8;
+   index  = ((uintptr_t)virtualBase / PAGE_SIZE) * 8;
 
    offset = lseek(pmapFd, index, SEEK_SET);
 
@@ -7343,7 +7374,9 @@ static int initZaps
 
       if (physical)
       {
-         dmaBus[basePage+n] = (dmaPage_t *) (physical | pi_dram_bus);
+         //cast twice to suppress warning, I belive this is ok as these
+         //are bus addresses, not virtual addresses. --plugwash
+         dmaBus[basePage+n] = (dmaPage_t *)(uintptr_t) (physical | pi_dram_bus);
 
          dmaVirt[basePage+n] = mmap
          (
@@ -7538,8 +7571,8 @@ static int initAllocDMAMem(void)
 
       close(fdPmap);
 
-      DBG(DBG_STARTUP, "dmaPMapBlk=%08X dmaIn=%08X",
-         (uint32_t)dmaPMapBlk, (uint32_t)dmaIn);
+      DBG(DBG_STARTUP, "dmaPMapBlk=%08"PRIXPTR" dmaIn=%08"PRIX64,
+         (uintptr_t)dmaPMapBlk, (uintptr_t)dmaIn);
    }
    else
    {
@@ -7571,17 +7604,17 @@ static int initAllocDMAMem(void)
 
       mbClose(fdMbox);
 
-      DBG(DBG_STARTUP, "dmaMboxBlk=%08X dmaIn=%08X",
-         (uint32_t)dmaMboxBlk, (uint32_t)dmaIn);
+      DBG(DBG_STARTUP, "dmaMboxBlk=%08"PRIXPTR" dmaIn=%08"PRIXPTR,
+         (uintptr_t)dmaMboxBlk, (uintptr_t)dmaIn);
    }
 
    DBG(DBG_STARTUP,
-      "gpioReg=%08X pwmReg=%08X pcmReg=%08X clkReg=%08X auxReg=%08X",
-      (uint32_t)gpioReg, (uint32_t)pwmReg,
-      (uint32_t)pcmReg,  (uint32_t)clkReg, (uint32_t)auxReg);
+      "gpioReg=%08"PRIX64" pwmReg=%08"PRIX64" pcmReg=%08"PRIX64" clkReg=%08"PRIX64" auxReg=%08"PRIX64,
+      (uintptr_t)gpioReg, (uintptr_t)pwmReg,
+      (uintptr_t)pcmReg,  (uintptr_t)clkReg, (uintptr_t)auxReg);
 
    for (i=0; i<DMAI_PAGES; i++)
-      DBG(DBG_STARTUP, "dmaIBus[%d]=%08X", i, (uint32_t)dmaIBus[i]);
+      DBG(DBG_STARTUP, "dmaIBus[%d]=%08"PRIX64, i, (uintptr_t)dmaIBus[i]);
 
    if (gpioCfg.dbgLevel >= DBG_DMACBS)
    {
@@ -8259,7 +8292,10 @@ int initInitialise(void)
 
    flushMemory();
 
-   initDMAgo((uint32_t *)dmaIn, (uint32_t)dmaIBus[0]);
+   //cast twice to suppress compiler warning, I belive this cast
+   //is ok because dmaIBus contains bus addresses, not virtual
+   //addresses.
+   initDMAgo((uint32_t *)dmaIn, (uint32_t)(uintptr_t)dmaIBus[0]);
 
    return PIGPIO_VERSION;
 }
@@ -8476,7 +8512,7 @@ void rawDumpScript(unsigned script_id)
       for (i=0; i<gpioScript[script_id].script.instrs; i++)
       {
          fprintf(stderr,
-            "c%d=[%d, %d(%d), %d(%d), %d, %d]\n",
+            "c%d=[%"PRIdPTR", %"PRIdPTR"(%d), %"PRIdPTR"(%d), %"PRIdPTR", %"PRIdPTR"]\n",
             i,
             gpioScript[script_id].script.instr[i].p[0],
             gpioScript[script_id].script.instr[i].p[1],
@@ -9120,7 +9156,7 @@ int gpioWaveAddGeneric(unsigned numPulses, gpioPulse_t *pulses)
 {
    int p;
 
-   DBG(DBG_USER, "numPulses=%u pulses=%08X", numPulses, (uint32_t)pulses);
+   DBG(DBG_USER, "numPulses=%u pulses=%08"PRIXPTR, numPulses, (uintptr_t)pulses);
 
    CHECK_INITED;
 
@@ -9292,8 +9328,8 @@ int rawWaveAddSPI(
    int tx_bit_pos;
 
    DBG(DBG_USER,
-      "spi=%08X off=%d spiSS=%d tx=%08X, num=%d fb=%d lb=%d spiBits=%d",
-      (uint32_t)spi, offset, spiSS, (uint32_t)buf, spiTxBits,
+      "spi=%08"PRIXPTR" off=%d spiSS=%d tx=%08"PRIXPTR", num=%d fb=%d lb=%d spiBits=%d",
+      (uintptr_t)spi, offset, spiSS, (uintptr_t)buf, spiTxBits,
       spiBitFirst, spiBitLast, spiBits);
 
    CHECK_INITED;
@@ -9653,7 +9689,9 @@ static uint32_t chainGetValPadr(int n)
       block = n / WCB_CHAIN_OOL;
       index = n % WCB_CHAIN_OOL;
       p = (uint32_t *) dmaOBus[block] + (WCB_COUNTER_CBS+WCB_CHAIN_CBS) * 8;
-      return (uint32_t) (p + index);
+      //cast twice to suppress warning, I belive this is ok as dmaOBus
+      //contains bus addresses not virtual addresses.
+      return (uint32_t)(uintptr_t) (p + index);
    }
    return 0;
 }
@@ -9685,7 +9723,9 @@ static uint32_t chainGetCntValPadr(int counter, int slot)
    page = counter / 2;
    offset = (counter % 2 ? WCB_COUNTER_OOL : 0);
    p = (uint32_t *) dmaOBus[page] + (WCB_COUNTER_CBS+WCB_CHAIN_CBS) * 8;
-   return (uint32_t)(p + WCB_CHAIN_OOL + offset + slot);
+   //cast twice to suppress warning, I belive this is ok as dmaOBus
+   //contains bus addresses not virtual addresses. --plugwash
+   return (uint32_t)(uintptr_t)(p + WCB_CHAIN_OOL + offset + slot);
 }
 
 static int chainGetCntCB(int counter)
@@ -9843,7 +9883,9 @@ int gpioWaveChain(char *buf, unsigned bufSize)
       p->dst  = PWM_TIMER;
    }
 
-   p->src    = (uint32_t) (&dmaOBus[0]->periphData);
+   //cast twice to suppress warning, I belive this is ok as dmaOBus
+   //contains bus addresses not virtual addresses. --plugwash
+   p->src    = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
    p->length = BPD * 20 / PI_WF_MICROS; /* 20 micros delay */
    p->next   = waveCbPOadr(chainGetCB(cb));
 
@@ -9933,8 +9975,10 @@ int gpioWaveChain(char *buf, unsigned bufSize)
 
                /* dummy src and dest */
                p->info = NORMAL_DMA;
-               p->src = (uint32_t) (&dmaOBus[0]->periphData);
-               p->dst = (uint32_t) (&dmaOBus[0]->periphData);
+               //cast twice to suppress warning, I belive this is ok as dmaOBus
+               //contains bus addresses not virtual addresses. --plugwash
+               p->src = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
+               p->dst = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
                p->length = 4;
                p->next = waveCbPOadr(chainGetCntCB(counters));
 
@@ -9985,7 +10029,9 @@ int gpioWaveChain(char *buf, unsigned bufSize)
                      p->dst  = PWM_TIMER;
                   }
 
-                  p->src = (uint32_t) (&dmaOBus[0]->periphData);
+                  //cast twice to suppress warning, I belive this is ok as dmaOBus
+                  //contains bus addresses not virtual addresses. --plugwash
+                  p->src = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
 
                   p->length = BPD * delayLeft / PI_WF_MICROS;
 
@@ -10024,8 +10070,10 @@ int gpioWaveChain(char *buf, unsigned bufSize)
 
             /* dummy src and dest */
             p->info = NORMAL_DMA;
-            p->src = (uint32_t) (&dmaOBus[0]->periphData);
-            p->dst = (uint32_t) (&dmaOBus[0]->periphData);
+            //cast twice to suppress warning, I belive this is ok as dmaOBus
+            //contains bus addresses not virtual addresses. --plugwash
+            p->src = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
+            p->dst = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
             p->length = 4;
             p->next = waveCbPOadr(chainGetCB(loop));
             endPtr = &p->next;
@@ -10072,8 +10120,11 @@ int gpioWaveChain(char *buf, unsigned bufSize)
    p = rawWaveCBAdr(chaincb);
 
    p->info   = NORMAL_DMA;
-   p->src    = (uint32_t) (&dmaOBus[0]->periphData);
-   p->dst    = (uint32_t) (&dmaOBus[0]->periphData);
+
+   //cast twice to suppress warning, I belive this is ok as dmaOBus
+   //contains bus addresses not virtual addresses. --plugwash
+   p->src    = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
+   p->dst    = (uint32_t)(uintptr_t) (&dmaOBus[0]->periphData);
    p->length = 4;
    p->next = 0;
 
@@ -10453,8 +10504,8 @@ int bbI2CZip(
    int addr, flags, esc, setesc;
    wfRx_t *w;
 
-   DBG(DBG_USER, "gpio=%d inBuf=%s outBuf=%08X len=%d",
-      SDA, myBuf2Str(inLen, (char *)inBuf), (int)outBuf, outLen);
+   DBG(DBG_USER, "gpio=%d inBuf=%s outBuf=%08"PRIX64" len=%d",
+      SDA, myBuf2Str(inLen, (char *)inBuf), (uintptr_t)outBuf, outLen);
 
    CHECK_INITED;
 
@@ -11009,8 +11060,8 @@ int bbSPIXfer(
    int pos;
    wfRx_t *w;
 
-   DBG(DBG_USER, "CS=%d inBuf=%s outBuf=%08X count=%d",
-      CS, myBuf2Str(count, (char *)inBuf), (int)outBuf, count);
+   DBG(DBG_USER, "CS=%d inBuf=%s outBuf=%08"PRIXPTR" count=%d",
+      CS, myBuf2Str(count, (char *)inBuf), (uintptr_t)outBuf, count);
 
    CHECK_INITED;
 
@@ -11137,7 +11188,7 @@ int gpioSerialRead(unsigned gpio, void *buf, size_t bufSize)
    unsigned bytes=0, wpos;
    volatile wfRx_t *w;
 
-   DBG(DBG_USER, "gpio=%d buf=%08X bufSize=%d", gpio, (int)buf, bufSize);
+   DBG(DBG_USER, "gpio=%d buf=%08"PRIXPTR" bufSize=%zd", gpio, (uintptr_t)buf, bufSize);
 
    CHECK_INITED;
 
@@ -11219,8 +11270,8 @@ static int intEventSetFunc(
    int      user,
    void *   userdata)
 {
-   DBG(DBG_INTERNAL, "event=%d function=%08X, user=%d, userdata=%08X",
-      event, (uint32_t)f, user, (uint32_t)userdata);
+   DBG(DBG_INTERNAL, "event=%d function=%08"PRIXPTR", user=%d, userdata=%08"PRIXPTR,
+      event, (uintptr_t)f, user, (uintptr_t)userdata);
 
    eventAlert[event].ex = user;
    eventAlert[event].userdata = userdata;
@@ -11235,7 +11286,7 @@ static int intEventSetFunc(
 
 int eventSetFunc(unsigned event, eventFunc_t f)
 {
-   DBG(DBG_USER, "event=%d function=%08X", event, (uint32_t)f);
+   DBG(DBG_USER, "event=%d function=%08"PRIXPTR, event, (uintptr_t)f);
 
    CHECK_INITED;
 
@@ -11252,8 +11303,8 @@ int eventSetFunc(unsigned event, eventFunc_t f)
 
 int eventSetFuncEx(unsigned event, eventFuncEx_t f, void *userdata)
 {
-   DBG(DBG_USER, "event=%d function=%08X userdata=%08X",
-      event, (uint32_t)f, (uint32_t)userdata);
+   DBG(DBG_USER, "event=%d function=%08"PRIx64" userdata=%08"PRIx64,
+      event, (uintptr_t)f, (uintptr_t)userdata);
 
    CHECK_INITED;
 
@@ -11311,8 +11362,8 @@ static int intGpioSetAlertFunc(
    int      user,
    void *   userdata)
 {
-   DBG(DBG_INTERNAL, "gpio=%d function=%08X, user=%d, userdata=%08X",
-      gpio, (uint32_t)f, user, (uint32_t)userdata);
+   DBG(DBG_INTERNAL, "gpio=%d function=%08"PRIXPTR", user=%d, userdata=%08"PRIXPTR,
+      gpio, (uintptr_t)f, user, (uintptr_t)userdata);
 
    gpioAlert[gpio].ex = user;
    gpioAlert[gpio].userdata = userdata;
@@ -11337,7 +11388,7 @@ static int intGpioSetAlertFunc(
 
 int gpioSetAlertFunc(unsigned gpio, gpioAlertFunc_t f)
 {
-   DBG(DBG_USER, "gpio=%d function=%08X", gpio, (uint32_t)f);
+   DBG(DBG_USER, "gpio=%d function=%08"PRIXPTR, gpio, (uintptr_t)f);
 
    CHECK_INITED;
 
@@ -11354,8 +11405,8 @@ int gpioSetAlertFunc(unsigned gpio, gpioAlertFunc_t f)
 
 int gpioSetAlertFuncEx(unsigned gpio, gpioAlertFuncEx_t f, void *userdata)
 {
-   DBG(DBG_USER, "gpio=%d function=%08X userdata=%08X",
-      gpio, (uint32_t)f, (uint32_t)userdata);
+   DBG(DBG_USER, "gpio=%d function=%08"PRIX64" userdata=%08"PRIX64,
+      gpio, (uintptr_t)f, (uintptr_t)userdata);
 
    CHECK_INITED;
 
@@ -11378,9 +11429,9 @@ static void *pthISRThread(void *x)
    struct pollfd pfd;
    char buf[64];
 
-   DBG(DBG_USER, "gpio=%d edge=%d timeout=%d f=%x u=%d data=%x",
-      isr->gpio, isr->edge, isr->timeout, (uint32_t)isr->func,
-      isr->ex, (uint32_t)isr->userdata);
+   DBG(DBG_USER, "gpio=%d edge=%d timeout=%d f=%"PRIxPTR" u=%d data=%"PRIxPTR,
+      isr->gpio, isr->edge, isr->timeout, (uintptr_t)isr->func,
+      isr->ex, (uintptr_t)isr->userdata);
 
    sprintf(buf, "/sys/class/gpio/gpio%d/value", isr->gpio);
 
@@ -11442,8 +11493,8 @@ static int intGpioSetISRFunc(
    int err;
 
    DBG(DBG_INTERNAL,
-      "gpio=%d edge=%d timeout=%d function=%08X user=%d userdata=%08X",
-      gpio, edge, timeout, (uint32_t)f, user, (uint32_t)userdata);
+      "gpio=%d edge=%d timeout=%d function=%08"PRIXPTR" user=%d userdata=%08"PRIXPTR,
+      gpio, edge, timeout, (uintptr_t)f, user, (uintptr_t)userdata);
 
    if (f)
    {
@@ -11536,8 +11587,8 @@ int gpioSetISRFunc(
    int timeout,
    gpioISRFunc_t f)
 {
-   DBG(DBG_USER, "gpio=%d edge=%d timeout=%d function=%08X",
-      gpio, edge, timeout, (uint32_t)f);
+   DBG(DBG_USER, "gpio=%d edge=%d timeout=%d function=%08"PRIXPTR,
+      gpio, edge, timeout, (uintptr_t)f);
 
    CHECK_INITED;
 
@@ -11560,8 +11611,8 @@ int gpioSetISRFuncEx(
    gpioAlertFuncEx_t f,
    void *userdata)
 {
-   DBG(DBG_USER, "gpio=%d edge=%d timeout=%d function=%08X userdata=%08X",
-      gpio, edge, timeout, (uint32_t)f, (uint32_t)userdata);
+   DBG(DBG_USER, "gpio=%d edge=%d timeout=%d function=%08"PRIXPTR" userdata=%08"PRIXPTR,
+      gpio, edge, timeout, (uintptr_t)f, (uintptr_t)userdata);
 
    CHECK_INITED;
 
@@ -11976,7 +12027,7 @@ int gpioGlitchFilter(unsigned gpio, unsigned steady)
 
 int gpioSetGetSamplesFunc(gpioGetSamplesFunc_t f, uint32_t bits)
 {
-   DBG(DBG_USER, "function=%08X bits=%08X", (uint32_t)f, bits);
+   DBG(DBG_USER, "function=%08"PRIXPTR" bits=%08X", (uintptr_t)f, bits);
 
    CHECK_INITED;
 
@@ -11999,7 +12050,7 @@ int gpioSetGetSamplesFuncEx(gpioGetSamplesFuncEx_t f,
                             uint32_t bits,
                             void * userdata)
 {
-   DBG(DBG_USER, "function=%08X bits=%08X", (uint32_t)f, bits);
+   DBG(DBG_USER, "function=%08"PRIXPTR" bits=%08X", (uintptr_t)f, bits);
 
    CHECK_INITED;
 
@@ -12026,8 +12077,8 @@ static int intGpioSetTimerFunc(unsigned id,
 {
    pthread_attr_t pthAttr;
 
-   DBG(DBG_INTERNAL, "id=%d millis=%d function=%08X user=%d userdata=%08X",
-      id, millis, (uint32_t)f, user, (uint32_t)userdata);
+   DBG(DBG_INTERNAL, "id=%d millis=%d function=%08"PRIXPTR" user=%d userdata=%08"PRIXPTR,
+      id, millis, (uintptr_t)f, user, (uintptr_t)userdata);
 
    gpioTimer[id].id   = id;
 
@@ -12091,7 +12142,7 @@ static int intGpioSetTimerFunc(unsigned id,
 
 int gpioSetTimerFunc(unsigned id, unsigned millis, gpioTimerFunc_t f)
 {
-   DBG(DBG_USER, "id=%d millis=%d function=%08X", id, millis, (uint32_t)f);
+   DBG(DBG_USER, "id=%d millis=%d function=%08"PRIXPTR, id, millis, (uintptr_t)f);
 
    CHECK_INITED;
 
@@ -12112,8 +12163,8 @@ int gpioSetTimerFunc(unsigned id, unsigned millis, gpioTimerFunc_t f)
 int gpioSetTimerFuncEx(unsigned id, unsigned millis, gpioTimerFuncEx_t f,
                        void * userdata)
 {
-   DBG(DBG_USER, "id=%d millis=%d function=%08X, userdata=%08X",
-      id, millis, (uint32_t)f, (uint32_t)userdata);
+   DBG(DBG_USER, "id=%d millis=%d function=%08"PRIXPTR", userdata=%08"PRIXPTR,
+      id, millis, (uintptr_t)f, (uintptr_t)userdata);
 
    CHECK_INITED;
 
@@ -12135,7 +12186,7 @@ pthread_t *gpioStartThread(gpioThreadFunc_t f, void *userdata)
    pthread_t *pth;
    pthread_attr_t pthAttr;
 
-   DBG(DBG_USER, "f=%08X, userdata=%08X", (uint32_t)f, (uint32_t)userdata);
+   DBG(DBG_USER, "f=%08"PRIXPTR", userdata=%08"PRIXPTR, (uintptr_t)f, (uintptr_t)userdata);
 
    CHECK_INITED_RET_NULL_PTR;
 
@@ -12168,7 +12219,7 @@ pthread_t *gpioStartThread(gpioThreadFunc_t f, void *userdata)
 
 void gpioStopThread(pthread_t *pth)
 {
-   DBG(DBG_USER, "pth=%08X", (uint32_t)pth);
+   DBG(DBG_USER, "pth=%08"PRIXPTR, (uintptr_t)pth);
 
    CHECK_INITED_RET_NIL;
 
@@ -12255,8 +12306,8 @@ int gpioRunScript(unsigned script_id, unsigned numParam, uint32_t *param)
 {
    int status = 0;
 
-   DBG(DBG_USER, "script_id=%d numParam=%d param=%08X",
-      script_id, numParam, (uint32_t)param);
+   DBG(DBG_USER, "script_id=%d numParam=%d param=%08"PRIXPTR,
+      script_id, numParam, (uintptr_t)param);
 
    CHECK_INITED;
 
@@ -12302,8 +12353,8 @@ int gpioRunScript(unsigned script_id, unsigned numParam, uint32_t *param)
 
 int gpioUpdateScript(unsigned script_id, unsigned numParam, uint32_t *param)
 {
-   DBG(DBG_USER, "script_id=%d numParam=%d param=%08X",
-      script_id, numParam, (uint32_t)param);
+   DBG(DBG_USER, "script_id=%d numParam=%d param=%08"PRIXPTR,
+      script_id, numParam, (uintptr_t)param);
 
    CHECK_INITED;
 
@@ -12334,7 +12385,7 @@ int gpioUpdateScript(unsigned script_id, unsigned numParam, uint32_t *param)
 
 int gpioScriptStatus(unsigned script_id, uint32_t *param)
 {
-   DBG(DBG_USER, "script_id=%d param=%08X", script_id, (uint32_t)param);
+   DBG(DBG_USER, "script_id=%d param=%08"PRIXPTR, script_id, (uintptr_t)param);
 
    CHECK_INITED;
 
@@ -12435,7 +12486,7 @@ int gpioDeleteScript(unsigned script_id)
 
 int gpioSetSignalFunc(unsigned signum, gpioSignalFunc_t f)
 {
-   DBG(DBG_USER, "signum=%d function=%08X", signum, (uint32_t)f);
+   DBG(DBG_USER, "signum=%d function=%08"PRIXPTR, signum, (uintptr_t)f);
 
    CHECK_INITED;
 
@@ -12456,8 +12507,8 @@ int gpioSetSignalFunc(unsigned signum, gpioSignalFunc_t f)
 int gpioSetSignalFuncEx(unsigned signum, gpioSignalFuncEx_t f,
                         void *userdata)
 {
-   DBG(DBG_USER, "signum=%d function=%08X userdata=%08X",
-      signum, (uint32_t)f, (uint32_t)userdata);
+   DBG(DBG_USER, "signum=%d function=%08"PRIXPTR" userdata=%08"PRIXPTR,
+      signum, (uintptr_t)f, (uintptr_t)userdata);
 
    CHECK_INITED;
 
@@ -13036,7 +13087,7 @@ int fileRead(unsigned handle, char *buf, unsigned count)
 {
    int r;
 
-   DBG(DBG_USER, "handle=%d count=%d buf=0x%X", handle, count, (unsigned)buf);
+   DBG(DBG_USER, "handle=%d count=%d buf=0x%"PRIXPTR, handle, count, (uintptr_t)buf);
 
    CHECK_INITED;
 
@@ -13117,7 +13168,7 @@ int fileList(char *fpat,  char *buf, unsigned count)
    glob_t pglob;
    int i;
 
-   DBG(DBG_USER, "fpat=%s count=%d buf=%x", fpat, count, (unsigned)buf);
+   DBG(DBG_USER, "fpat=%s count=%d buf=%"PRIxPTR, fpat, count, (uintptr_t)buf);
 
    CHECK_INITED;
 
@@ -13157,8 +13208,8 @@ int gpioTime(unsigned timetype, int *seconds, int *micros)
 {
    struct timespec ts;
 
-   DBG(DBG_USER, "timetype=%d &seconds=%08X &micros=%08X",
-      timetype, (uint32_t)seconds, (uint32_t)micros);
+   DBG(DBG_USER, "timetype=%d &seconds=%08"PRIXPTR" &micros=%08"PRIXPTR,
+      timetype, (uintptr_t)seconds, (uintptr_t)micros);
 
    CHECK_INITED;
 
@@ -13449,7 +13500,7 @@ int gpioCfgDMAchannels(unsigned primaryChannel, unsigned secondaryChannel)
 
 int gpioCfgPermissions(uint64_t updateMask)
 {
-   DBG(DBG_USER, "gpio update mask=%llX", updateMask);
+   DBG(DBG_USER, "gpio update mask=%"PRIX64, updateMask);
 
    CHECK_NOT_INITED;
 
@@ -13517,8 +13568,8 @@ int gpioCfgNetAddr(int numSockAddr, uint32_t *sockAddr)
 {
    int i;
 
-   DBG(DBG_USER, "numSockAddr=%d sockAddr=%08X",
-      numSockAddr, (unsigned)sockAddr);
+   DBG(DBG_USER, "numSockAddr=%d sockAddr=%08"PRIXPTR,
+      numSockAddr, (uintptr_t)sockAddr);
 
    CHECK_NOT_INITED;
 

--- a/pigpio.c
+++ b/pigpio.c
@@ -1198,6 +1198,7 @@ typedef struct
 /* initialise once then preserve */
 
 static volatile uint32_t piCores      = 0;
+static volatile uint32_t pi_ispi      = 0;
 static volatile uint32_t pi_peri_phys = 0x20000000;
 static volatile uint32_t pi_dram_bus  = 0x40000000;
 static volatile uint32_t pi_mem_flag  = 0x0C;
@@ -7197,6 +7198,17 @@ static uint32_t * initMapMem(int fd, uint32_t addr, uint32_t len)
 static int initCheckPermitted(void)
 {
    DBG(DBG_STARTUP, "");
+
+   if (!pi_ispi)
+   {
+      DBG(DBG_ALWAYS,
+         "\n" \
+         "+---------------------------------------------------------+\n" \
+         "|Sorry, this system does not appear to be a raspberry pi. |\n" \
+         "|aborting.                                                |\n" \
+         "+---------------------------------------------------------+\n\n");
+      return -1;
+   }
 
    if ((fdMem = open("/dev/mem", O_RDWR | O_SYNC) ) < 0)
    {
@@ -13324,6 +13336,13 @@ unsigned gpioHardwareRevision(void)
                   pi_dram_bus  = 0xC0000000;
                   pi_mem_flag  = 0x04;
                }
+            }
+         }
+
+         if (!strncasecmp("hardware\t: BCM", buf, 14)) {
+            int bcmno = atoi(buf+14);
+            if ((bcmno == 2708) || (bcmno == 2709) || (bcmno == 2710) || (bcmno == 2835) || (bcmno == 2836) || (bcmno == 2837)) {
+              pi_ispi = 1;
             }
          }
 

--- a/pigpio.c
+++ b/pigpio.c
@@ -7572,7 +7572,7 @@ static int initAllocDMAMem(void)
 
       close(fdPmap);
 
-      DBG(DBG_STARTUP, "dmaPMapBlk=%08"PRIXPTR" dmaIn=%08"PRIX64,
+      DBG(DBG_STARTUP, "dmaPMapBlk=%08"PRIXPTR" dmaIn=%08"PRIXPTR,
          (uintptr_t)dmaPMapBlk, (uintptr_t)dmaIn);
    }
    else
@@ -7610,12 +7610,12 @@ static int initAllocDMAMem(void)
    }
 
    DBG(DBG_STARTUP,
-      "gpioReg=%08"PRIX64" pwmReg=%08"PRIX64" pcmReg=%08"PRIX64" clkReg=%08"PRIX64" auxReg=%08"PRIX64,
+      "gpioReg=%08"PRIXPTR" pwmReg=%08"PRIXPTR" pcmReg=%08"PRIXPTR" clkReg=%08"PRIXPTR" auxReg=%08"PRIXPTR,
       (uintptr_t)gpioReg, (uintptr_t)pwmReg,
       (uintptr_t)pcmReg,  (uintptr_t)clkReg, (uintptr_t)auxReg);
 
    for (i=0; i<DMAI_PAGES; i++)
-      DBG(DBG_STARTUP, "dmaIBus[%d]=%08"PRIX64, i, (uintptr_t)dmaIBus[i]);
+      DBG(DBG_STARTUP, "dmaIBus[%d]=%08"PRIXPTR, i, (uintptr_t)dmaIBus[i]);
 
    if (gpioCfg.dbgLevel >= DBG_DMACBS)
    {
@@ -10505,7 +10505,7 @@ int bbI2CZip(
    int addr, flags, esc, setesc;
    wfRx_t *w;
 
-   DBG(DBG_USER, "gpio=%d inBuf=%s outBuf=%08"PRIX64" len=%d",
+   DBG(DBG_USER, "gpio=%d inBuf=%s outBuf=%08"PRIXPTR" len=%d",
       SDA, myBuf2Str(inLen, (char *)inBuf), (uintptr_t)outBuf, outLen);
 
    CHECK_INITED;
@@ -11304,7 +11304,7 @@ int eventSetFunc(unsigned event, eventFunc_t f)
 
 int eventSetFuncEx(unsigned event, eventFuncEx_t f, void *userdata)
 {
-   DBG(DBG_USER, "event=%d function=%08"PRIx64" userdata=%08"PRIx64,
+   DBG(DBG_USER, "event=%d function=%08"PRIxPTR" userdata=%08"PRIxPTR,
       event, (uintptr_t)f, (uintptr_t)userdata);
 
    CHECK_INITED;
@@ -11406,7 +11406,7 @@ int gpioSetAlertFunc(unsigned gpio, gpioAlertFunc_t f)
 
 int gpioSetAlertFuncEx(unsigned gpio, gpioAlertFuncEx_t f, void *userdata)
 {
-   DBG(DBG_USER, "gpio=%d function=%08"PRIX64" userdata=%08"PRIX64,
+   DBG(DBG_USER, "gpio=%d function=%08"PRIXPTR" userdata=%08"PRIXPTR,
       gpio, (uintptr_t)f, (uintptr_t)userdata);
 
    CHECK_INITED;

--- a/pigs.c
+++ b/pigs.c
@@ -300,7 +300,7 @@ int main(int argc , char *argv[])
    int sock, command;
    int args, idx, i, pp, l, len;
    cmdCmd_t cmd;
-   uint32_t p[CMD_P_ARR];
+   uintptr_t p[CMD_P_ARR];
    cmdCtlParse_t ctl;
    cmdScript_t s;
    char v[CMD_MAX_EXTENSION];


### PR DESCRIPTION
These commits add code to check if the device is actually a raspberry pi and fix a bunch of 64-bit cleanliness issues in the code.

Note after making these fixes I tried to test on a Debian arm64 system, but I found that Debian kernels lack a feature needed for pigpio. At this time I have not tested on a "downstream" arm64 kernel.