### PR TITLE
correct format to print data

### DIFF
--- a/EXAMPLES/Python/WIEGAND_CODE/wiegand.py
+++ b/EXAMPLES/Python/WIEGAND_CODE/wiegand.py
@@ -121,7 +121,9 @@ if __name__ == "__main__":
    import wiegand
 
    def callback(bits, value):
-      print("bits={} value={}".format(bits, value))
+      card_id = int("{:026b}".format(value)[1:25],2)
+      print("bits={} value={:026b}".format(bits, value))
+      print("Card ID: {:010d}".format(card_id))
 
    pi = pigpio.pi()
 


### PR DESCRIPTION
binary "value" is translated to int in "format" function. also leading zeroes are omitted. that leads to print a strange number.
thanks to:  
(https://www.raspberrypi.org/forums/viewtopic.php?t=124114)  
(https://github.com/joan2937/pigpio/issues/30)