### PR TITLE
Fix cmake setup for yocto

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ if(Python_FOUND)
 		${CMAKE_CURRENT_BINARY_DIR}/setup.py
 	)
 
-	install(CODE "execute_process(${Python_EXECUTABLE} setup.py install)")
+	install(CODE "execute_process(${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py install)")
 endif()
 #
 #install(CODE "execute_process(COMMAND ldconfig)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,8 +130,7 @@ install(FILES ${man_3_SRC}
 find_package(Python COMPONENTS Interpreter QUIET)
 
 if(Python_FOUND)
-	message(STATUS "Installing python modules.")
-	install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/setup.py install)")
+	install(CODE "execute_process(COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/setup.py install)")
 endif()
 #
 #install(CODE "execute_process(COMMAND ldconfig)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,9 +129,9 @@ install(FILES ${man_3_SRC}
 
 find_package(Python COMPONENTS Interpreter QUIET)
 
-file(GLOB setup_SRC "setup.py")
 if(Python_FOUND)
-	install(CODE "execute_process(COMMAND cd ${CMAKE_SOURCE_DIR} && ${Python_EXECUTABLE} ${setup_SRC} install)")
+	message(STATUS "Installing python modules.")
+	install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/setup.py install)")
 endif()
 #
 #install(CODE "execute_process(COMMAND ldconfig)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,7 @@ list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 find_package(Threads REQUIRED)
 find_package(RT REQUIRED)
 
-if(NOT DEFINED BUILD_SHARED_LIBS)
-set(BUILD_SHARED_LIBS "ON")
-endif(NOT DEFINED BUILD_SHARED_LIBS)
+option(BUILD_SHARED_LIBS "Create shared libraries" ON)
 
 add_compile_options(-Wall)
 
@@ -21,7 +19,6 @@ add_library(pigpiod_if pigpiod_if.c command.c)
 
 # libpigpiod_if2.(so|a)
 add_library(pigpiod_if2 pigpiod_if2.c command.c)
-
 
 # x_pigpio
 add_executable(x_pigpio x_pigpio.c)
@@ -47,20 +44,12 @@ target_link_libraries(pigs Threads::Threads)
 add_executable(pig2vcd pig2vcd.c command.c)
 target_link_libraries(pig2vcd Threads::Threads)
 
-# install
+# Configure and install project
 
 include (GenerateExportHeader)
 include (CMakePackageConfigHelpers)
 
 generate_export_header(${PROJECT_NAME})
-
-#install(DIRECTORY
-#	DESTINATION ${DESTDIR}/opt/pigpio/cgi
-#	PATTERN ""
-#	PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
-#		GROUP_READ GROUP_EXECUTE
-#		WORLD_READ WORLD_EXECUTE
-#)
 
 install(TARGETS pigpio pigpiod_if pigpiod_if2 pig2vcd pigpiod pigs
     EXPORT ${PROJECT_NAME}Targets
@@ -80,11 +69,6 @@ export(EXPORT ${PROJECT_NAME}Targets
   FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake"
   NAMESPACE pigpio::
 )
-
-#configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake/${PROJECT_NAME}Config.cmake
-#  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-#  COPYONLY
-#)
 
 set(ConfigPackageLocation lib/cmake/${PROJECT_NAME})
 install(EXPORT ${PROJECT_NAME}Targets
@@ -127,6 +111,7 @@ install(FILES ${man_3_SRC}
 		WORLD_READ
 )
 
+# Install python modules.
 find_package(Python COMPONENTS Interpreter QUIET)
 
 if(Python_FOUND)
@@ -136,22 +121,6 @@ if(Python_FOUND)
 
 	install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py install)")
 endif()
-#
-#install(CODE "execute_process(COMMAND ldconfig)")
-
-# One does not need a uninstall command if every file was installed via cmake
-# install commands. That python script however seems to need some more
-# script code.
-# uninstall
-#if(Python_FOUND)
-#	set(PY_CMD ${Python_EXECUTABLE} ${setup_SRC} install --record /tmp/pigpio > /dev/null)
-#	set(PY_CMD ${PY2_CMD} && xargs rm -f < /tmp/pigpio > /dev/null)
-#endif()
-
-#add_custom_target(uninstall
-#	COMMAND cd ${CMAKE_SOURCE_DIR} && ${PY_CMD}
-#)
-
 
 # package project
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,11 @@ install(FILES ${man_3_SRC}
 find_package(Python COMPONENTS Interpreter QUIET)
 
 if(Python_FOUND)
-	install(CODE "execute_process(COMMAND cd ${CMAKE_CURRENT_SOURCE_DIR} && ${Python_EXECUTABLE} ${CMAKE_SOURCE_DIR}/setup.py install)")
+	configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake/setup.py.in
+		${CMAKE_CURRENT_BINARY_DIR}/setup.py
+	)
+
+	install(CODE "execute_process(${Python_EXECUTABLE} setup.py install)")
 endif()
 #
 #install(CODE "execute_process(COMMAND ldconfig)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,10 +129,10 @@ install(FILES ${man_3_SRC}
 
 find_package(Python COMPONENTS Interpreter QUIET)
 
-#file(GLOB setup_SRC "setup.py")
-#if(Python_FOUND)
-#	install(CODE "execute_process(COMMAND cd ${CMAKE_SOURCE_DIR} && ${Python_EXECUTABLE} ${setup_SRC} install)")
-#endif()
+file(GLOB setup_SRC "setup.py")
+if(Python_FOUND)
+	install(CODE "execute_process(COMMAND cd ${CMAKE_SOURCE_DIR} && ${Python_EXECUTABLE} ${setup_SRC} install)")
+endif()
 #
 #install(CODE "execute_process(COMMAND ldconfig)")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,11 +29,11 @@ target_link_libraries(x_pigpio pigpio RT::RT Threads::Threads)
 
 # x_pigpiod_if
 add_executable(x_pigpiod_if x_pigpiod_if.c)
-target_link_libraries(x_pigpiod_if pigpio_if RT::RT Threads::Threads)
+target_link_libraries(x_pigpiod_if pigpiod_if RT::RT Threads::Threads)
 
 # x_pigpiod_if2
 add_executable(x_pigpiod_if2 x_pigpiod_if2.c)
-target_link_libraries(x_pigpiod_if2 pigpio_if2 RT::RT Threads::Threads)
+target_link_libraries(x_pigpiod_if2 pigpiod_if2 RT::RT Threads::Threads)
 
 # pigpiod
 add_executable(pigpiod pigpiod.c)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,17 @@
 cmake_minimum_required(VERSION 3.0)
 
-project(pigpio)
+project(pigpio LANGUAGES C VERSION 0.71)
 
-set(CMAKE_C_FLAGS "-O3 -Wall -pthread")
-set(PIGPIO_FLAGS "-L. -lrt")
-#set(DESTDIR ${CMAKE_CURRENT_SOURCE_DIR}/build/dest)
+list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+
+find_package(Threads REQUIRED)
+find_package(RT REQUIRED)
 
 if(NOT DEFINED BUILD_SHARED_LIBS)
 set(BUILD_SHARED_LIBS "ON")
 endif(NOT DEFINED BUILD_SHARED_LIBS)
+
+add_compile_options(-Wall)
 
 # libpigpio.(so|a)
 add_library(pigpio pigpio.c command.c custom.cext)
@@ -22,59 +25,87 @@ add_library(pigpiod_if2 pigpiod_if2.c command.c)
 
 # x_pigpio
 add_executable(x_pigpio x_pigpio.c)
-add_dependencies(x_pigpio pigpio)
-target_link_libraries(x_pigpio
-	${PIGPIO_FLAGS}
-	-lpigpio
-)
+target_link_libraries(x_pigpio pigpio RT::RT Threads::Threads)
 
 # x_pigpiod_if
 add_executable(x_pigpiod_if x_pigpiod_if.c)
-add_dependencies(x_pigpiod_if pigpiod_if)
-target_link_libraries(x_pigpiod_if
-	${PIGPIO_FLAGS}
-	-lpigpiod_if
-)
+target_link_libraries(x_pigpiod_if pigpio_if RT::RT Threads::Threads)
 
 # x_pigpiod_if2
 add_executable(x_pigpiod_if2 x_pigpiod_if2.c)
-add_dependencies(x_pigpiod_if2 pigpiod_if2)
-target_link_libraries(x_pigpiod_if2
-	${PIGPIO_FLAGS}
-	-lpigpiod_if2
-)
+target_link_libraries(x_pigpiod_if2 pigpio_if2 RT::RT Threads::Threads)
 
 # pigpiod
 add_executable(pigpiod pigpiod.c)
-add_dependencies(pigpiod pigpio)
-target_link_libraries(pigpiod
-	${PIGPIO_FLAGS}
-	-lpigpio
-)
+target_link_libraries(pigpiod pigpio RT::RT Threads::Threads)
 
 # pigs
 add_executable(pigs pigs.c command.c)
+target_link_libraries(pigs Threads::Threads)
 
 # pig2vcd
 add_executable(pig2vcd pig2vcd.c command.c)
+target_link_libraries(pig2vcd Threads::Threads)
 
 # install
-install(DIRECTORY
-	DESTINATION ${DESTDIR}/opt/pigpio/cgi
-	PATTERN ""
-	PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
-		GROUP_READ GROUP_EXECUTE
-		WORLD_READ WORLD_EXECUTE
-)
+
+include (GenerateExportHeader)
+include (CMakePackageConfigHelpers)
+
+generate_export_header(${PROJECT_NAME})
+
+#install(DIRECTORY
+#	DESTINATION ${DESTDIR}/opt/pigpio/cgi
+#	PATTERN ""
+#	PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ
+#		GROUP_READ GROUP_EXECUTE
+#		WORLD_READ WORLD_EXECUTE
+#)
 
 install(TARGETS pigpio pigpiod_if pigpiod_if2 pig2vcd pigpiod pigs
-	LIBRARY DESTINATION ${DESTDIR}/usr/local/lib
-	RUNTIME DESTINATION ${DESTDIR}/usr/local/bin
-	ARCHIVE DESTINATION ${DESTDIR}/usr/local/lib
+    EXPORT ${PROJECT_NAME}Targets
+	LIBRARY  DESTINATION lib
+	ARCHIVE  DESTINATION lib
+	RUNTIME  DESTINATION bin
+	INCLUDES DESTINATION include
+)
+
+write_basic_package_version_file(
+	"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+	VERSION ${${PROJECT_NAME}_VERSION}
+	COMPATIBILITY AnyNewerVersion
+)
+
+export(EXPORT ${PROJECT_NAME}Targets
+  FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake"
+  NAMESPACE pigpio::
+)
+
+#configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake/${PROJECT_NAME}Config.cmake
+#  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+#  COPYONLY
+#)
+
+set(ConfigPackageLocation lib/cmake/${PROJECT_NAME})
+install(EXPORT ${PROJECT_NAME}Targets
+  FILE
+    ${PROJECT_NAME}Targets.cmake
+  NAMESPACE
+    pigpio::
+  DESTINATION
+    ${ConfigPackageLocation}
+)
+
+install(
+  FILES
+    ${CMAKE_CURRENT_LIST_DIR}/cmake/${PROJECT_NAME}Config.cmake
+    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+  DESTINATION
+    ${ConfigPackageLocation}
 )
 
 install(FILES pigpio.h pigpiod_if.h pigpiod_if2.h
-	DESTINATION ${DESTDIR}/usr/local/include
+	DESTINATION include
 	PERMISSIONS OWNER_READ OWNER_WRITE
 		GROUP_READ
 		WORLD_READ
@@ -82,7 +113,7 @@ install(FILES pigpio.h pigpiod_if.h pigpiod_if2.h
 
 file(GLOB man_1_SRC "*.1")
 install(FILES ${man_1_SRC}
-	DESTINATION ${DESTDIR}/usr/local/man/man1
+	DESTINATION man/man1
 	PERMISSIONS OWNER_READ OWNER_WRITE
 		GROUP_READ
 		WORLD_READ
@@ -90,48 +121,35 @@ install(FILES ${man_1_SRC}
 
 file(GLOB man_3_SRC "*.3")
 install(FILES ${man_3_SRC}
-	DESTINATION ${DESTDIR}/usr/local/man/man3
+	DESTINATION man/man3
 	PERMISSIONS OWNER_READ OWNER_WRITE
 		GROUP_READ
 		WORLD_READ
 )
 
-file(GLOB setup_SRC "setup.py")
-find_program(PYTHON2_FOUND python2)
-if(PYTHON2_FOUND)
-	install(CODE "execute_process(COMMAND cd ${CMAKE_SOURCE_DIR} && python2 ${setup_SRC} install)")
-endif()
-find_program(PYTHON3_FOUND python3)
-if(PYTHON3_FOUND)
-	install(CODE "execute_process(COMMAND cd ${CMAKE_SOURCE_DIR} && python3 ${setup_SRC} install)")
-endif()
+find_package(Python COMPONENTS Interpreter QUIET)
 
-install(CODE "execute_process(COMMAND ldconfig)")
+#file(GLOB setup_SRC "setup.py")
+#if(Python_FOUND)
+#	install(CODE "execute_process(COMMAND cd ${CMAKE_SOURCE_DIR} && ${Python_EXECUTABLE} ${setup_SRC} install)")
+#endif()
+#
+#install(CODE "execute_process(COMMAND ldconfig)")
 
+# One does not need a uninstall command if every file was installed via cmake
+# install commands. That python script however seems to need some more
+# script code.
 # uninstall
-if(PYTHON2_FOUND)
-	set(PY2_CMD python2 ${setup_SRC} install --record /tmp/pigpio > /dev/null)
-	set(PY2_CMD ${PY2_CMD} && xargs rm -f < /tmp/pigpio > /dev/null)
-endif()
+#if(Python_FOUND)
+#	set(PY_CMD ${Python_EXECUTABLE} ${setup_SRC} install --record /tmp/pigpio > /dev/null)
+#	set(PY_CMD ${PY2_CMD} && xargs rm -f < /tmp/pigpio > /dev/null)
+#endif()
 
-if(PYTHON3_FOUND)
-	set(PY3_CMD python3 ${setup_SRC} install --record /tmp/pigpio > /dev/null)
-	set(PY3_CMD ${PY3_CMD} && xargs rm -f < /tmp/pigpio > /dev/null)
-endif()
+#add_custom_target(uninstall
+#	COMMAND cd ${CMAKE_SOURCE_DIR} && ${PY_CMD}
+#)
 
-add_custom_target(uninstall
-	COMMAND rm -f ${DESTDIR}/usr/local/include/pigpio.h
-	COMMAND rm -f ${DESTDIR}/usr/local/include/pigpiod_if.h
-	COMMAND rm -f ${DESTDIR}/usr/local/include/pigpiod_if2.h
-	COMMAND rm -f ${DESTDIR}/usr/local/lib/libpigpio.so
-	COMMAND rm -f ${DESTDIR}/usr/local/lib/libpigpiod_if.so
-	COMMAND rm -f ${DESTDIR}/usr/local/lib/libpigpiod_if2.so
-	COMMAND rm -f ${DESTDIR}/usr/local/bin/pig2vcd
-	COMMAND rm -f ${DESTDIR}/usr/local/bin/pigpiod
-	COMMAND rm -f ${DESTDIR}/usr/local/bin/pigs
-	COMMAND cd ${CMAKE_SOURCE_DIR} && ${PY2_CMD}
-	COMMAND cd ${CMAKE_SOURCE_DIR} && ${PY3_CMD}
-	COMMAND rm -f ${DESTDIR}/usr/local/man/man1/pig*.1
-	COMMAND rm -f ${DESTDIR}/usr/local/man/man3/pig*.3
-	COMMAND ldconfig
-)
+
+# package project
+
+include (CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,7 +134,7 @@ if(Python_FOUND)
 		${CMAKE_CURRENT_BINARY_DIR}/setup.py
 	)
 
-	install(CODE "execute_process(${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py install)")
+	install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py install)")
 endif()
 #
 #install(CODE "execute_process(COMMAND ldconfig)")

--- a/cmake/FindRT.cmake
+++ b/cmake/FindRT.cmake
@@ -1,0 +1,39 @@
+# FindRT.cmake - Try to find the RT library
+# Once done this will define
+#
+#  RT_FOUND - System has rt
+#  RT_INCLUDE_DIR - The rt include directory
+#  RT_LIBRARIES - The libraries needed to use rt
+#  RT_DEFINITIONS - Compiler switches required for using rt
+#
+# Also creates an import target called RT::RT
+
+find_path (RT_INCLUDE_DIR NAMES time.h
+  PATHS
+  /usr
+  /usr/local
+  /opt
+  PATH_SUFFIXES
+)
+
+find_library(RT_LIBRARIES NAMES rt
+  PATHS
+  /usr
+  /usr/local
+  /opt
+)
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(rt DEFAULT_MSG RT_LIBRARIES RT_INCLUDE_DIR)
+
+mark_as_advanced(RT_INCLUDE_DIR RT_LIBRARIES)
+
+if (NOT TARGET RT::RT)
+  add_library(RT::RT INTERFACE IMPORTED)
+
+  set_target_properties(RT::RT PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES ${RT_INCLUDE_DIR}
+    INTERFACE_LINK_LIBRARIES ${RT_LIBRARIES}
+  )
+endif()

--- a/cmake/pigpioConfig.cmake
+++ b/cmake/pigpioConfig.cmake
@@ -1,0 +1,1 @@
+include (${CMAKE_CURRENT_LIST_DIR}/pigpioTargets.cmake)

--- a/cmake/setup.py.in
+++ b/cmake/setup.py.in
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+from distutils.core import setup
+
+setup(name='pigpio',
+      version='1.44',
+      author='joan',
+      author_email='joan@abyz.me.uk',
+      maintainer='joan',
+      maintainer_email='joan@abyz.me.uk',
+      url='http://abyz.me.uk/rpi/pigpio/python.html',
+      description='Raspberry Pi GPIO module',
+      long_description='Raspberry Pi Python module to access the pigpio daemon',
+      download_url='http://abyz.me.uk/rpi/pigpio/pigpio.zip',
+      license='unlicense.org',
+      py_modules=['pigpio'],
+      keywords=['raspberrypi', 'gpio',],
+      classifiers=[
+         "Programming Language :: Python :: 2",
+         "Programming Language :: Python :: 3",
+      ],
+      package_dir={ '': '${CMAKE_CURRENT_SOURCE_DIR}'}
+     )
+


### PR DESCRIPTION
The current cmake setup of the pigpio project was incompatible with a yocto build for the raspberry pi. For some reason it had problems finding standard header files like <stdio.h>. However the builds succeeded on non Yocto builds which reinforced my suspicion that the CMake setup was the cause.

Nevertheless I modernized the CMake setup, which now also builds in a yocto environment :D. The new CMake conforms with the current CMake 3.0 standard. As such the following features are available.

 - Usage of CMAKE_INSTALL_PREFIX instead of the custom DEST_DIR
 - Usage of CMAKE_BUILD_TYPE to determine Release/Debug or RelWithDebInfo builds.
 - Usage of CMake versioning system
 - Create a CMake importable package configuration for all configurations.
 - Create a CMake installer via CPack (build the package target)
 - Usage of dependency handling via CMake target architecture (no more add_dependencies)
 - Finding of external dependencies via CMake (CMake will raise an error if -lpthread or -lrt are not present on the system)
 - Moved the option like option (BUILD_SHARED_LIBS) to an actual option (default is ON).
 - Removed the uninstall target (CMake tracks all install commands and provides an uninstall target, however this is not compatible with the custom python module setup.py)

I wrote these enhancements for our own raspberry pi yocto builds, which require pigpio. We used to use WiringPi, however that project got disbanded by the maintainer himself, which is sad. Nevertheless the pigpio project works equally amazing.

