### PR TITLE
add docker image and github actions autobuild

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+EXAMPLES
+Dockerfile
+.github

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,42 @@
+name: build docker image
+
+on: [push]
+
+jobs:
+  build:
+    name: build images and push
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - name: install qemu
+        run: docker run --rm --privileged hypriot/qemu-register
+
+      - name: checkout
+        uses: actions/checkout@v1
+
+      - name: login to docker hub
+        run: echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+
+      - name: install buildx
+        run: |
+          mkdir -vp ~/.docker/cli-plugins/ ~/dockercache
+          curl --silent -L "https://github.com/docker/buildx/releases/download/v0.3.0/buildx-v0.3.0.linux-amd64" > ~/.docker/cli-plugins/docker-buildx
+          chmod a+x ~/.docker/cli-plugins/docker-buildx
+          docker buildx create --use
+
+      - name: display head_ref
+        run: echo ${GITHUB_HEAD_REF}
+
+      - name: build image and push to hub
+        if: github.head_ref == 'refs/heads/master'
+        run: |
+          docker buildx build --push \
+            --platform linux/arm/v7,linux/arm64/v8 \
+            -t $GITHUB_REPOSITORY:latest \
+            .
+
+      - name: build image
+        if: github.head_ref != 'refs/heads/master'
+        run: |
+          docker buildx build --platform linux/arm/v7,linux/arm64/v8  .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM debian:buster AS builder
+
+RUN apt-get update \
+  && apt-get install -y make gcc \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workdir
+COPY . /workdir
+RUN make install
+
+FROM debian:buster-slim
+
+COPY --from=builder /usr/local/lib/libpigpio.so.1 /usr/local/lib/libpigpio.so.1
+COPY --from=builder /usr/local/bin/pigpiod /usr/local/bin/pigpiod
+
+RUN ldconfig
+
+CMD ["/usr/local/bin/pigpiod", "-g"]


### PR DESCRIPTION
Create a docker image for `pigpiod` and pushes it to the hub when done on master.
You need to put your username and password in the secrets to be able to push to docker hub.
An [image](https://hub.docker.com/r/jdrouet/pigpio) is actually building on my fork for arm32v7 and arm64v8.