### PR TITLE
Fix broken close handling

### DIFF
--- a/pigpio.c
+++ b/pigpio.c
@@ -13582,8 +13582,8 @@ unsigned gpioHardwareRevision(void)
                   }
                }
             }
+            fclose(filp);
          }
-         fclose(filp);
       }
 
       if (rev == 0)


### PR DESCRIPTION
Don't try to `fclose` a `NULL` and `SIGSEGV`.