### PR TITLE
Release v74

### DIFF
--- a/pigpio.c
+++ b/pigpio.c
@@ -13521,7 +13521,7 @@ unsigned gpioHardwareRevision(void)
 
    if ((rev & 0x800000) == 0) /* old rev code */
    {
-      if (rev < 16) /* all BCM2835 */
+      if (rev < 0x0016) /* all BCM2835 */
       {
          pi_ispi = 1;
          piCores = 1;

--- a/pigpio.c
+++ b/pigpio.c
@@ -25,7 +25,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org/>
 */
 
-/* pigpio version 7303 */
+/* pigpio version 74 */
 
 /* include ------------------------------------------------------- */
 

--- a/pigpio.c
+++ b/pigpio.c
@@ -8292,7 +8292,7 @@ int initInitialise(void)
             }
             server6.sin6_port = htons(port);
 
-            int opt;
+            int opt = 1;
             setsockopt(fdSock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
             if (bind(fdSock,(struct sockaddr *)&server6, sizeof(server6)) < 0)
                SOFT_ERROR(PI_INIT_FAILED, "bind to port %d failed (%m)", port);
@@ -8307,7 +8307,7 @@ int initInitialise(void)
             SOFT_ERROR(PI_INIT_FAILED, "socket failed (%m)");
          else
          {
-           int opt;
+           int opt = 1;
            setsockopt(fdSock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
          }
          server.sin_family = AF_INET;

--- a/pigpio.h
+++ b/pigpio.h
@@ -30,7 +30,7 @@ For more information, please refer to <http://unlicense.org/>
 #include <stdint.h>
 #include <pthread.h>
 
-#define PIGPIO_VERSION 73
+#define PIGPIO_VERSION 7301
 
 /*TEXT
 

--- a/pigpio.h
+++ b/pigpio.h
@@ -30,7 +30,7 @@ For more information, please refer to <http://unlicense.org/>
 #include <stdint.h>
 #include <pthread.h>
 
-#define PIGPIO_VERSION 7301
+#define PIGPIO_VERSION 7302
 
 /*TEXT
 

--- a/pigpio.h
+++ b/pigpio.h
@@ -30,7 +30,7 @@ For more information, please refer to <http://unlicense.org/>
 #include <stdint.h>
 #include <pthread.h>
 
-#define PIGPIO_VERSION 7303
+#define PIGPIO_VERSION 74
 
 /*TEXT
 

--- a/pigpio.h
+++ b/pigpio.h
@@ -30,7 +30,7 @@ For more information, please refer to <http://unlicense.org/>
 #include <stdint.h>
 #include <pthread.h>
 
-#define PIGPIO_VERSION 7302
+#define PIGPIO_VERSION 7303
 
 /*TEXT
 


### PR DESCRIPTION
Joan, with your review and approval, V74 is ready to merge to the master branch.  I plan to do this next week (Feb).

This release contains the following changes:

1. Mea culpa, this change initializes the parameter for setsockopt() to enable address reuse.  Issues #274 and #298 are the targets of this change.  I did not hear back from the authors of those issues but my own testing shows this to be an intermittent problem that is fixed.

2. New hardware revision decode scheme addresses issues #266 and #316.  This change was tested by the authors of those issues and reported to work on 64-bit OS.  My own testing found an issue with a legacy revision code and this was subsequently fixed.  My testing covered all generations of raspberry pi **except** Pi4 (I don't own this hw, yet).  Mostly for this reason, I'd like to keep this PR open until someone can verify on a Pi4.  User level debug messages were added that will enable a quick verification of the failure signature should a user encounter a problem.

3. A 'cherry-picked' commit from PR #225 that fixes issue #223.  All tests pass.