### PR TITLE
Bcm2711 bsc slave

### DIFF
--- a/pigpio.3
+++ b/pigpio.3
@@ -1683,6 +1683,15 @@ will be a latency.
 .br
 
 .br
+If you want to track the level of more than one GPIO do so by
+maintaining the state in the callback.  Do not use \fBgpioRead\fP.
+Remember the event that triggered the callback may have
+happened several milliseconds before and the GPIO may have
+changed level many times since then.
+
+.br
+
+.br
 The tick value is the time stamp of the sample in microseconds, see
 \fBgpioTick\fP for more details.
 
@@ -4182,12 +4191,6 @@ queue and the master removes it.
 .br
 
 .br
-This function is not available on the BCM2711 (e.g. as
-used in the Pi4B).
-
-.br
-
-.br
 I can't get SPI to work properly.  I tried with a
 control word of 0x303 and swapped MISO and MOSI.
 
@@ -4249,14 +4252,37 @@ that mode until a different control word is sent.
 .br
 
 .br
-The BSC peripheral uses GPIO 18 (SDA) and 19 (SCL) in I2C mode
-and GPIO 18 (MOSI), 19 (SCLK), 20 (MISO), and 21 (CE) in SPI mode.  You
-need to swap MISO/MOSI between master and slave.
+GPIO used for models other than those based on the BCM2711.
 
 .br
 
 .br
-When a zero control word is received GPIO 18-21 will be reset
+      SDA   SCL   MOSI   SCLK   MISO   CE
+.br
+I2C   18    19    -      -      -      -
+.br
+SPI   -     -     18     19     20     21
+.br
+
+.br
+
+.br
+GPIO used for models based on the BCM2711 (e.g. the Pi4B).
+
+.br
+
+.br
+      SDA   SCL   MOSI   SCLK   MISO   CE
+.br
+I2C   10    11    -      -      -      -
+.br
+SPI   -     -     10     11     9      8
+.br
+
+.br
+
+.br
+When a zero control word is received the used GPIO will be reset
 to INPUT mode.
 
 .br

--- a/pigpio.h
+++ b/pigpio.h
@@ -30,7 +30,7 @@ For more information, please refer to <http://unlicense.org/>
 #include <stdint.h>
 #include <pthread.h>
 
-#define PIGPIO_VERSION 74
+#define PIGPIO_VERSION 7401
 
 /*TEXT
 
@@ -797,6 +797,11 @@ typedef void *(gpioThreadFunc_t) (void *);
 #define BSC_MISO     20
 #define BSC_CE_N     21
 
+#define BSC_SDA_MOSI_2711 10
+#define BSC_SCL_SCLK_2711 11
+#define BSC_MISO_2711      9
+#define BSC_CE_N_2711      8
+
 /* Longest busy delay */
 
 #define PI_MAX_BUSY_DELAY 100
@@ -1438,6 +1443,12 @@ The thread which calls the alert functions is triggered nominally
 once per level change since the last time the thread was activated.
 i.e. The active alert functions will get all level changes but there
 will be a latency.
+
+If you want to track the level of more than one GPIO do so by
+maintaining the state in the callback.  Do not use [*gpioRead*].
+Remember the event that triggered the callback may have
+happened several milliseconds before and the GPIO may have
+changed level many times since then.
 
 The tick value is the time stamp of the sample in microseconds, see
 [*gpioTick*] for more details.
@@ -2913,9 +2924,6 @@ The output process is simple. You simply append data to the FIFO
 buffer on the chip.  This works like a queue, you add data to the
 queue and the master removes it.
 
-This function is not available on the BCM2711 (e.g. as
-used in the Pi4B).
-
 I can't get SPI to work properly.  I tried with a
 control word of 0x303 and swapped MISO and MOSI.
 
@@ -2947,11 +2955,19 @@ in rxBuf.
 Note that the control word sets the BSC mode.  The BSC will stay in
 that mode until a different control word is sent.
 
-The BSC peripheral uses GPIO 18 (SDA) and 19 (SCL) in I2C mode
-and GPIO 18 (MOSI), 19 (SCLK), 20 (MISO), and 21 (CE) in SPI mode.  You
-need to swap MISO/MOSI between master and slave.
+GPIO used for models other than those based on the BCM2711.
 
-When a zero control word is received GPIO 18-21 will be reset
+    @ SDA @ SCL @ MOSI @ SCLK @ MISO @ CE
+I2C @ 18  @ 19  @ -    @ -    @ -    @ -
+SPI @ -   @ -   @ 18   @ 19   @ 20   @ 21
+
+GPIO used for models based on the BCM2711 (e.g. the Pi4B).
+
+    @ SDA @ SCL @ MOSI @ SCLK @ MISO @ CE
+I2C @ 10  @ 11  @ -    @ -    @ -    @ -
+SPI @ -   @ -   @ 10   @ 11   @ 9    @ 8
+
+When a zero control word is received the used GPIO will be reset
 to INPUT mode.
 
 The returned function value is the status of the transfer (see below).

--- a/pigpiod_if2.3
+++ b/pigpiod_if2.3
@@ -5920,6 +5920,66 @@ tick        32 bit   The number of microseconds since boot
 
 .EE
 
+.br
+
+.br
+The GPIO are sampled at a rate set when the pigpio daemon
+is started (default 5 us).
+
+.br
+
+.br
+The number of samples per second is given in the following table.
+
+.br
+
+.br
+
+.EX
+              samples
+.br
+              per sec
+.br
+
+.br
+         1  1,000,000
+.br
+         2    500,000
+.br
+sample   4    250,000
+.br
+rate     5    200,000
+.br
+(us)     8    125,000
+.br
+        10    100,000
+.br
+
+.EE
+
+.br
+
+.br
+GPIO level changes shorter than the sample rate may be missed.
+
+.br
+
+.br
+The daemon software which generates the callbacks is triggered
+1000 times per second.  The callbacks will be called once per
+level change since the last time they were called.
+i.e. The callbacks will get all level changes but there will
+be a latency.
+
+.br
+
+.br
+If you want to track the level of more than one GPIO do so by
+maintaining the state in the callback.  Do not use \fBgpio_read\fP.
+Remember the event that triggered the callback may have
+happened several milliseconds before and the GPIO may have
+changed level many times since then.
+
 .IP "\fBint callback_ex(int pi, unsigned user_gpio, unsigned edge, CBFuncEx_t f, void *userdata)\fP"
 .IP "" 4
 This function initialises a new callback.
@@ -6073,12 +6133,6 @@ queue and the master removes it.
 .br
 
 .br
-This function is not available on the BCM2711 (e.g. as
-used in the Pi4B).
-
-.br
-
-.br
 I can't get SPI to work properly.  I tried with a
 control word of 0x303 and swapped MISO and MOSI.
 
@@ -6160,14 +6214,37 @@ that mode until a different control word is sent.
 .br
 
 .br
-The BSC peripheral uses GPIO 18 (SDA) and 19 (SCL) in I2C mode
-and GPIO 18 (MOSI), 19 (SCLK), 20 (MISO), and 21 (CE) in SPI mode.  You
-need to swap MISO/MOSI between master and slave.
+GPIO used for models other than those based on the BCM2711.
 
 .br
 
 .br
-When a zero control word is received GPIO 18-21 will be reset
+      SDA   SCL   MOSI   SCLK   MISO   CE
+.br
+I2C   18    19    -      -      -      -
+.br
+SPI   -     -     18     19     20     21
+.br
+
+.br
+
+.br
+GPIO used for models based on the BCM2711 (e.g. the Pi4B).
+
+.br
+
+.br
+      SDA   SCL   MOSI   SCLK   MISO   CE
+.br
+I2C   10    11    -      -      -      -
+.br
+SPI   -     -     10     11     9      8
+.br
+
+.br
+
+.br
+When a zero control word is received the used GPIO will be reset
 to INPUT mode.
 
 .br
@@ -6390,8 +6467,7 @@ If there was an error the status will be less than zero
 
 .br
 Note that an i2c_address of 0 may be used to close
-the BSC device and reassign the used GPIO (18/19)
-as inputs.
+the BSC device and reassign the used GPIO as inputs.
 
 .IP "\fBint event_callback(int pi, unsigned event, evtCBFunc_t f)\fP"
 .IP "" 4

--- a/pigpiod_if2.c
+++ b/pigpiod_if2.c
@@ -25,7 +25,7 @@ OTHER DEALINGS IN THE SOFTWARE.
 For more information, please refer to <http://unlicense.org/>
 */
 
-/* PIGPIOD_IF2_VERSION 16 */
+/* PIGPIOD_IF2_VERSION 17 */
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/pigs.1
+++ b/pigs.1
@@ -926,10 +926,6 @@ buffer on the chip.  This works like a queue, you add data to the
 queue and the master removes it.
 
 .br
-This function is not available on the BCM2711 (e.g. as
-used in the Pi4B).
-
-.br
 I can't get SPI to work properly.  I tried with a
 control word of 0x303 and swapped MISO and MOSI.
 
@@ -950,12 +946,31 @@ For I2C use a control word of (I2C address << 16) + 0x305.
 E.g. to talk as I2C slave with address 0x13 use 0x130305.
 
 .br
-The BSC peripheral uses GPIO 18 (SDA) and 19 (SCL) in I2C mode
-and GPIO 18 (MOSI), 19 (SCLK), 20 (MISO), and 21 (CE) in SPI mode.  You
-need to swap MISO/MOSI between master and slave.
+GPIO used for models other than those based on the BCM2711.
 
 .br
-When a zero control word is received GPIO 18-21 will be reset
+
+.EX
+      SDA   SCL   MOSI   SCLK   MISO   CE
+I2C   18    19    -      -      -      -
+SPI   -     -     18     19     20     21
+
+.EE
+
+.br
+GPIO used for models based on the BCM2711 (e.g. the Pi4B).
+
+.br
+
+.EX
+      SDA   SCL   MOSI   SCLK   MISO   CE
+I2C   10    11    -      -      -      -
+SPI   -     -     10     11     9      8
+
+.EE
+
+.br
+When a zero control word is received the used GPIO will be reset
 to INPUT mode.
 
 .br
@@ -1031,7 +1046,8 @@ TB      transmit busy
 .EE
 
 .br
-This example assumes that GPIO 2/3 are connected to GPIO 18/19.
+This example assumes that GPIO 2/3 are connected to GPIO 18/19
+(GPIO 10/11 on the BCM2711).
 
 .br
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from distutils.core import setup
 
 setup(name='pigpio',
-      version='1.45',
+      version='1.46',
       author='joan',
       author_email='joan@abyz.me.uk',
       maintainer='joan',


### PR DESCRIPTION
Added code for BSC I2C/SPI slave on the BCM2711 (PI4B) and corrected an error in GPIO mode
setting for SPI as slave which existed in the earlier implementation.

Added explanatory documentation for callback usage.
