### PR TITLE
Adds padded waves to the API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.o
 *.so
+*.so.*
 *.pyc
 pig2vcd
 pigpiod

--- a/command.c
+++ b/command.c
@@ -201,7 +201,7 @@ cmdInfo_t cmdInfo[]=
    {PI_CMD_WVBSY, "WVBSY", 101, 2, 1}, // gpioWaveTxBusy
    {PI_CMD_WVCHA, "WVCHA", 197, 0, 0}, // gpioWaveChain
    {PI_CMD_WVCLR, "WVCLR", 101, 0, 1}, // gpioWaveClear
-   {PI_CMD_WVCRE, "WVCRE", 112, 2, 1}, // gpioWaveCreate
+   {PI_CMD_WVCRE, "WVCRE", 101, 2, 1}, // gpioWaveCreate
    {PI_CMD_WVDEL, "WVDEL", 112, 0, 1}, // gpioWaveDelete
    {PI_CMD_WVGO,  "WVGO" , 101, 2, 0}, // gpioWaveTxStart
    {PI_CMD_WVGOR, "WVGOR", 101, 2, 0}, // gpioWaveTxStart

--- a/command.c
+++ b/command.c
@@ -201,7 +201,7 @@ cmdInfo_t cmdInfo[]=
    {PI_CMD_WVBSY, "WVBSY", 101, 2, 1}, // gpioWaveTxBusy
    {PI_CMD_WVCHA, "WVCHA", 197, 0, 0}, // gpioWaveChain
    {PI_CMD_WVCLR, "WVCLR", 101, 0, 1}, // gpioWaveClear
-   {PI_CMD_WVCRE, "WVCRE", 101, 2, 1}, // gpioWaveCreate
+   {PI_CMD_WVCRE, "WVCRE", 112, 2, 1}, // gpioWaveCreate
    {PI_CMD_WVDEL, "WVDEL", 112, 0, 1}, // gpioWaveDelete
    {PI_CMD_WVGO,  "WVGO" , 101, 2, 0}, // gpioWaveTxStart
    {PI_CMD_WVGOR, "WVGOR", 101, 2, 0}, // gpioWaveTxStart

--- a/command.c
+++ b/command.c
@@ -201,7 +201,8 @@ cmdInfo_t cmdInfo[]=
    {PI_CMD_WVBSY, "WVBSY", 101, 2, 1}, // gpioWaveTxBusy
    {PI_CMD_WVCHA, "WVCHA", 197, 0, 0}, // gpioWaveChain
    {PI_CMD_WVCLR, "WVCLR", 101, 0, 1}, // gpioWaveClear
-   {PI_CMD_WVCRE, "WVCRE", 101, 2, 1}, // gpioWaveCreate
+   {PI_CMD_WVCRE, "WVCRE", 101, 2, 1}, // gpioWaveCreate 
+   {PI_CMD_WVCAP, "WVCAP", 112, 2, 1}, // gpioWaveCreatePad
    {PI_CMD_WVDEL, "WVDEL", 112, 0, 1}, // gpioWaveDelete
    {PI_CMD_WVGO,  "WVGO" , 101, 2, 0}, // gpioWaveTxStart
    {PI_CMD_WVGOR, "WVGOR", 101, 2, 0}, // gpioWaveTxStart

--- a/pigpio.c
+++ b/pigpio.c
@@ -3130,24 +3130,27 @@ static int wave2Cbs(unsigned wave_mode, int *CB, int *BOOL, int *TOOL, int size)
       }
    }
 
-   /* pad the wave */
-   botCB = *CB + NUM_WAVE_CBS / size - 1;
-   botOOL = *BOOL + NUM_WAVE_OOL / size - 1;
-   //topOOL = *TOOL - (NUM_WAVE_OOL / size / 8);
+   if (size)
+   {
+      /* pad the wave */
 
-   /* link the last CB to end of wave */
+      botCB = *CB + NUM_WAVE_CBS / size - 1;
+      botOOL = *BOOL + NUM_WAVE_OOL / size - 1;
+      //topOOL =   //Fix:  Ignore topOOL, flags not supported.
 
-   p->next = waveCbPOadr(botCB);
-   
-   /* add dummy cb at end of DMA */
-   
-   p = rawWaveCBAdr(botCB++);
-   p->info   = NORMAL_DMA | DMA_DEST_IGNORE;
-   p->src    = waveOOLPOadr(botOOL++);
-   p->dst    = ((GPIO_BASE + (GPSET0*4)) & 0x00ffffff) | PI_PERI_BUS;
-   p->length = 4;
-   p->next   = 0;
+      /* link the last CB to end of wave */
 
+      p->next = waveCbPOadr(botCB);
+
+      /* add dummy cb at end of DMA */
+
+      p = rawWaveCBAdr(botCB++);
+      p->info   = NORMAL_DMA | DMA_DEST_IGNORE;
+      p->src    = waveOOLPOadr(botOOL++);
+      p->dst    = ((GPIO_BASE + (GPSET0*4)) & 0x00ffffff) | PI_PERI_BUS;
+      p->length = 4;
+      p->next   = 0;
+   }
 
    if (p != NULL)
    {

--- a/pigpio.c
+++ b/pigpio.c
@@ -2432,7 +2432,7 @@ static int myDoCommand(uintptr_t *p, unsigned bufSize, char *buf)
 
       case PI_CMD_WVCLR: res = gpioWaveClear(); break;
 
-      case PI_CMD_WVCRE: res = gpioWaveCreate(); break;
+      case PI_CMD_WVCRE: res = gpioWaveCreate(p[1]); break;
 
       case PI_CMD_WVDEL: res = gpioWaveDelete(p[1]); break;
 
@@ -2992,7 +2992,7 @@ static void waveCBsOOLs(int *numCBs, int *numBOOLs, int *numTOOLs)
 
 /* ----------------------------------------------------------------------- */
 
-static int wave2Cbs(unsigned wave_mode, int *CB, int *BOOL, int *TOOL)
+static int wave2Cbs(unsigned wave_mode, int *CB, int *BOOL, int *TOOL, int size)
 {
    int botCB=*CB, botOOL=*BOOL, topOOL=*TOOL;
 
@@ -3129,6 +3129,25 @@ static int wave2Cbs(unsigned wave_mode, int *CB, int *BOOL, int *TOOL)
          }
       }
    }
+
+   /* pad the wave */
+   botCB = *CB + NUM_WAVE_CBS / size - 1;
+   botOOL = *BOOL + NUM_WAVE_OOL / size - 1;
+   //topOOL = *TOOL - (NUM_WAVE_OOL / size / 8);
+
+   /* link the last CB to end of wave */
+
+   p->next = waveCbPOadr(botCB);
+   
+   /* add dummy cb at end of DMA */
+   
+   p = rawWaveCBAdr(botCB++);
+   p->info   = NORMAL_DMA | DMA_DEST_IGNORE;
+   p->src    = waveOOLPOadr(botOOL++);
+   p->dst    = ((GPIO_BASE + (GPSET0*4)) & 0x00ffffff) | PI_PERI_BUS;
+   p->length = 4;
+   p->next   = 0;
+
 
    if (p != NULL)
    {
@@ -9552,7 +9571,7 @@ int rawWaveAddSPI(
 
 /* ----------------------------------------------------------------------- */
 
-int gpioWaveCreate(void)
+int gpioWaveCreate(int size)  // Fix: Make variadic.
 {
    int i, wid;
    int numCB, numBOOL, numTOOL;
@@ -9566,7 +9585,14 @@ int gpioWaveCreate(void)
 
    /* What resources are needed? */
 
-   waveCBsOOLs(&numCB, &numBOOL, &numTOOL);
+   if (size == 0)
+      waveCBsOOLs(&numCB, &numBOOL, &numTOOL);
+
+   else {
+      numCB = NUM_WAVE_CBS / size;
+      numBOOL = NUM_WAVE_OOL / size;
+      numTOOL = 0;  // ignore TOOL, ie, no flags support
+   }
 
    wid = -1;
 
@@ -9619,7 +9645,7 @@ int gpioWaveCreate(void)
    BOOL = waveInfo[wid].botOOL;
    TOOL = waveInfo[wid].topOOL;
 
-   wave2Cbs(PI_WAVE_MODE_ONE_SHOT, &CB, &BOOL, &TOOL);
+   wave2Cbs(PI_WAVE_MODE_ONE_SHOT, &CB, &BOOL, &TOOL, size);
 
    /* Sanity check. */
 
@@ -9632,6 +9658,9 @@ int gpioWaveCreate(void)
          numBOOL, BOOL-waveInfo[wid].botOOL,
          numTOOL, waveInfo[wid].topOOL-TOOL);
    }
+
+   DBG(DBG_USER, "Wave Stats: wid=%d CBs %d BOOL %d TOOL %d", wid,
+      numCB, numBOOL, numTOOL);
 
    waveInfo[wid].deleted = 0;
 

--- a/pigpio.h
+++ b/pigpio.h
@@ -1986,6 +1986,43 @@ Returns the new waveform id if OK, otherwise PI_EMPTY_WAVEFORM,
 PI_NO_WAVEFORM_ID, PI_TOO_MANY_CBS, or PI_TOO_MANY_OOL.
 D*/
 
+int gpioWaveCreatePad(int percent);
+/*D
+This function creates a waveform like wave_create but pads the consumed
+resources. Where percent gives the percentage of the resources to use (in terms
+of the theoretical maximum, not the current amount free). This allows the reuse 
+of deleted waves while a transmission is active. Upon success a wave id
+greater than or equal to 0 is returned, otherwise PI_EMPTY_WAVEFORM,
+PI_TOO_MANY_CBS, PI_TOO_MANY_OOL, or PI_NO_WAVEFORM_ID.
+
+. .
+pi: >=0 (as returned by [*pigpio_start*]).
+. .
+
+The data provided by the [*wave_add_**] functions is consumed by this
+function.
+
+As many waveforms may be created as there is space available. The
+wave id is passed to [*wave_send_**] to specify the waveform to transmit.
+
+A usage would be the creation of two waves where one is filled while the other
+is beeing transmitted. Each wave is assigned 50% of the available resources.
+This buffer structure allows the transmission of infinite wave sequences.
+
+Step 1. [*wave_clear*] to clear all waveforms and added data.
+
+Step 2. [*wave_add_**] calls to supply the waveform data.
+
+Step 3. [*wave_create_and_pad*] to create a 50% padded waveform and get a unique id
+
+Step 4. [*wave_send_**] with the id of the waveform to transmit.
+
+Repeat steps 2-4 as needed always waiting for the active waveform to be transmitted
+before marking it as deleted.
+
+Returns the new waveform id if OK, otherwise PI_EMPTY_WAVEFORM,
+PI_NO_WAVEFORM_ID, PI_TOO_MANY_CBS, or PI_TOO_MANY_OOL.
+D*/
 
 /*F*/
 int gpioWaveDelete(unsigned wave_id);
@@ -6271,6 +6308,7 @@ PARAMS*/
 #define PI_CMD_EVT   116
 
 #define PI_CMD_PROCU 117
+#define PI_CMD_WVCAP 118
 
 /*DEF_E*/
 

--- a/pigpio.h
+++ b/pigpio.h
@@ -1933,7 +1933,7 @@ D*/
 
 
 /*F*/
-int gpioWaveCreate(int);
+int gpioWaveCreate(void);
 /*D
 This function creates a waveform from the data provided by the prior
 calls to the [*gpioWaveAdd**] functions.  Upon success a wave id

--- a/pigpio.h
+++ b/pigpio.h
@@ -1933,7 +1933,7 @@ D*/
 
 
 /*F*/
-int gpioWaveCreate(void);
+int gpioWaveCreate(int);
 /*D
 This function creates a waveform from the data provided by the prior
 calls to the [*gpioWaveAdd**] functions.  Upon success a wave id

--- a/pigpio.py
+++ b/pigpio.py
@@ -571,6 +571,7 @@ _PI_CMD_EVM  =115
 _PI_CMD_EVT  =116
 
 _PI_CMD_PROCU=117
+_PI_CMD_WVCAP=118
 
 # pigpio error numbers
 
@@ -2303,6 +2304,42 @@ class pi():
       ...
       """
       return _u2i(_pigpio_command(self.sl, _PI_CMD_WVCRE, 0, 0))
+
+   def wave_create_and_pad(self, percent):
+      """
+      This function creates a waveform like wave_create but pads the consumed
+      resources. Where percent gives the percentage of the resources to use (in terms
+      of the theoretical maximum, not the current amount free). This allows the reuse 
+      of deleted waves while a transmission is active. Upon success a wave id
+      greater than or equal to 0 is returned, otherwise PI_EMPTY_WAVEFORM,
+      PI_TOO_MANY_CBS, PI_TOO_MANY_OOL, or PI_NO_WAVEFORM_ID.
+
+      . .
+      pi: >=0 (as returned by [*pigpio_start*]).
+      . .
+
+      The data provided by the [*wave_add_**] functions is consumed by this
+      function.
+
+      As many waveforms may be created as there is space available. The
+      wave id is passed to [*wave_send_**] to specify the waveform to transmit.
+
+      A usage would be the creation of two waves where one is filled while the other
+      is beeing transmitted. Each wave is assigned 50% of the available resources.
+      This buffer structure allows the transmission of infinite wave sequences.
+
+      Step 1. [*wave_clear*] to clear all waveforms and added data.
+
+      Step 2. [*wave_add_**] calls to supply the waveform data.
+
+      Step 3. [*wave_create_and_pad*] to create a 50% padded waveform and get a unique id
+
+      Step 4. [*wave_send_**] with the id of the waveform to transmit.
+
+      Repeat steps 2-4 as needed always waiting for the active waveform to be transmitted
+      before marking it as deleted.
+      """
+      return _u2i(_pigpio_command(self.sl, _PI_CMD_WVCAP, percent, 0))
 
    def wave_delete(self, wave_id):
       """

--- a/pigpio.py
+++ b/pigpio.py
@@ -2257,7 +2257,7 @@ class pi():
       else:
          return 0
 
-   def wave_create(self, size):
+   def wave_create(self):
       """
       Creates a waveform from the data provided by the prior calls
       to the [*wave_add_**] functions.
@@ -2302,7 +2302,7 @@ class pi():
       wid = pi.wave_create()
       ...
       """
-      return _u2i(_pigpio_command(self.sl, _PI_CMD_WVCRE, size, 0))
+      return _u2i(_pigpio_command(self.sl, _PI_CMD_WVCRE, 0, 0))
 
    def wave_delete(self, wave_id):
       """

--- a/pigpio.py
+++ b/pigpio.py
@@ -2257,7 +2257,7 @@ class pi():
       else:
          return 0
 
-   def wave_create(self):
+   def wave_create(self, size):
       """
       Creates a waveform from the data provided by the prior calls
       to the [*wave_add_**] functions.
@@ -2302,7 +2302,7 @@ class pi():
       wid = pi.wave_create()
       ...
       """
-      return _u2i(_pigpio_command(self.sl, _PI_CMD_WVCRE, 0, 0))
+      return _u2i(_pigpio_command(self.sl, _PI_CMD_WVCRE, size, 0))
 
    def wave_delete(self, wave_id):
       """

--- a/pigpiod_if2.c
+++ b/pigpiod_if2.c
@@ -953,6 +953,9 @@ int wave_add_serial(
 int wave_create(int pi)
    {return pigpio_command(pi, PI_CMD_WVCRE, 0, 0, 1);}
 
+int wave_create_and_pad(int pi, int percent)
+   {return pigpio_command(pi, PI_CMD_WVCAP, percent, 0, 1);}
+
 int wave_delete(int pi, unsigned wave_id)
    {return pigpio_command(pi, PI_CMD_WVDEL, wave_id, 0, 1);}
 

--- a/pigpiod_if2.h
+++ b/pigpiod_if2.h
@@ -1371,6 +1371,43 @@ Returns the new waveform id if OK, otherwise PI_EMPTY_WAVEFORM,
 PI_NO_WAVEFORM_ID, PI_TOO_MANY_CBS, or PI_TOO_MANY_OOL.
 D*/
 
+int wave_create_and_pad(int pi, int percent);
+/*D
+This function creates a waveform like wave_create but pads the consumed
+resources. Where percent gives the percentage of the resources to use (in terms
+of the theoretical maximum, not the current amount free). This allows the reuse 
+of deleted waves while a transmission is active. Upon success a wave id
+greater than or equal to 0 is returned, otherwise PI_EMPTY_WAVEFORM,
+PI_TOO_MANY_CBS, PI_TOO_MANY_OOL, or PI_NO_WAVEFORM_ID.
+
+. .
+pi: >=0 (as returned by [*pigpio_start*]).
+. .
+
+The data provided by the [*wave_add_**] functions is consumed by this
+function.
+
+As many waveforms may be created as there is space available. The
+wave id is passed to [*wave_send_**] to specify the waveform to transmit.
+
+A usage would be the creation of two waves where one is filled while the other
+is beeing transmitted. Each wave is assigned 50% of the available resources.
+This buffer structure allows the transmission of infinite wave sequences.
+
+Step 1. [*wave_clear*] to clear all waveforms and added data.
+
+Step 2. [*wave_add_**] calls to supply the waveform data.
+
+Step 3. [*wave_create_and_pad*] to create a 50% padded waveform and get a unique id
+
+Step 4. [*wave_send_**] with the id of the waveform to transmit.
+
+Repeat steps 2-4 as needed always waiting for the active waveform to be transmitted
+before marking it as deleted.
+
+Returns the new waveform id if OK, otherwise PI_EMPTY_WAVEFORM,
+PI_NO_WAVEFORM_ID, PI_TOO_MANY_CBS, or PI_TOO_MANY_OOL.
+D*/
 
 /*F*/
 int wave_delete(int pi, unsigned wave_id);

--- a/x_pigpio.c
+++ b/x_pigpio.c
@@ -391,7 +391,7 @@ To the lascivious pleasing of a lute.\n\
    e = gpioWaveAddGeneric(4, wf);
    CHECK(5, 2, e, 4, 0, "pulse, wave add generic");
 
-   wid = gpioWaveCreate(0);
+   wid = gpioWaveCreate();
    e = gpioWaveTxSend(wid, PI_WAVE_MODE_REPEAT);
    if (e < 14) CHECK(5, 3, e,  9, 0, "wave tx repeat");
    else        CHECK(5, 3, e, 19, 0, "wave tx repeat");
@@ -413,7 +413,7 @@ To the lascivious pleasing of a lute.\n\
    e = gpioWaveAddSerial(GPIO, BAUD, 8, 2, 5000000, strlen(TEXT), TEXT);
    CHECK(5, 7, e, 3405, 0, "wave clear, wave add serial");
 
-   wid = gpioWaveCreate(0);
+   wid = gpioWaveCreate();
    e = gpioWaveTxSend(wid, PI_WAVE_MODE_ONE_SHOT);
    if (e < 6964) CHECK(5, 8, e, 6811, 0, "wave tx start");
    else          CHECK(5, 8, e, 7116, 0, "wave tx start");

--- a/x_pigpio.c
+++ b/x_pigpio.c
@@ -391,7 +391,7 @@ To the lascivious pleasing of a lute.\n\
    e = gpioWaveAddGeneric(4, wf);
    CHECK(5, 2, e, 4, 0, "pulse, wave add generic");
 
-   wid = gpioWaveCreate();
+   wid = gpioWaveCreate(0);
    e = gpioWaveTxSend(wid, PI_WAVE_MODE_REPEAT);
    if (e < 14) CHECK(5, 3, e,  9, 0, "wave tx repeat");
    else        CHECK(5, 3, e, 19, 0, "wave tx repeat");
@@ -413,7 +413,7 @@ To the lascivious pleasing of a lute.\n\
    e = gpioWaveAddSerial(GPIO, BAUD, 8, 2, 5000000, strlen(TEXT), TEXT);
    CHECK(5, 7, e, 3405, 0, "wave clear, wave add serial");
 
-   wid = gpioWaveCreate();
+   wid = gpioWaveCreate(0);
    e = gpioWaveTxSend(wid, PI_WAVE_MODE_ONE_SHOT);
    if (e < 6964) CHECK(5, 8, e, 6811, 0, "wave tx start");
    else          CHECK(5, 8, e, 7116, 0, "wave tx start");


### PR DESCRIPTION
Task list for releasing this feature:

- [x] Measure jitter on a fixed frequency continuous wave. @guymcswain
       3.6 usec after 10 minutes (10 KHz square wave)
- [x] Test adding wave larger than pad size. @guymcswain 
- [x] Review the construction of the 'sentinel' DMA Control Block. @joan2937
https://github.com/Jul3k/pigpio/blob/c660e3fc8e23c80bbc2f025ac659e07d9f3045e1/pigpio.c#L3147-L3155
- [x] Investigate issue when setting percent close to 50% (was size>2 issue before) @guymcswain 
- [x] Decide if percentage should be specified out of a million as done for PWM dutycycle.
- [x] Test waveChain sub-commands with padded waves. (guy)
- [x] Test mixing native waves and padded waves. (guy)
- [x] Add test cases to x_* for padded waves.
- [x] Add documentation for new APIs.
- [x] Target release for April in v76. @guymcswain