### PR TITLE
Fix initPeripherals on Ubuntu 20.04

### DIFF
--- a/pigpio.c
+++ b/pigpio.c
@@ -7262,7 +7262,7 @@ static int initGrabLockFile(void)
 static uint32_t * initMapMem(int fd, uint32_t addr, uint32_t len)
 {
     return (uint32_t *) mmap(0, len,
-       PROT_READ|PROT_WRITE|PROT_EXEC,
+       PROT_READ|PROT_WRITE,
        MAP_SHARED|MAP_LOCKED,
        fd, addr);
 }


### PR DESCRIPTION
I've encountered `initPeripherals: mmap gpio failed(Operation not permitted)` due to PROT_EXEC on Ubuntu 20.04 64bit.
Remove PROT_EXEC from initMapMem.