### PR TITLE
Glitch filter unexpected callback

### DIFF
--- a/pigpio.c
+++ b/pigpio.c
@@ -950,6 +950,7 @@ typedef struct
    uint32_t nfRBitV;
 
    uint32_t gfSteadyUs;
+   uint8_t  gfInitialised;
    uint32_t gfTick;
    uint32_t gfLBitV;
    uint32_t gfRBitV;
@@ -5683,7 +5684,7 @@ unsigned alert_delays[]=
 static void alertGlitchFilter(gpioSample_t *sample, int numSamples)
 {
    int i, j, diff;
-   uint32_t steadyUs, changedTick, RBitV, LBitV;
+   uint32_t steadyUs, changedTick, RBitV, LBitV, initialised;
    uint32_t bit, bitV;
 
    for (i=0; i<=PI_MAX_USER_GPIO; i++)
@@ -5692,6 +5693,17 @@ static void alertGlitchFilter(gpioSample_t *sample, int numSamples)
 
       if (monitorBits & bit & gFilterBits)
       {
+         initialised = gpioAlert[i].gfInitialised;
+         if (!initialised && numSamples > 0)
+         {
+           /* Initialise filter with first sample */
+           bitV = sample[0].level & bit;
+           gpioAlert[i].gfRBitV = bitV;
+           gpioAlert[i].gfLBitV = bitV;
+           gpioAlert[i].gfTick = sample[0].tick;
+           gpioAlert[i].gfInitialised = 1;
+         }
+
          steadyUs    = gpioAlert[i].gfSteadyUs;
          RBitV       = gpioAlert[i].gfRBitV;
          LBitV       = gpioAlert[i].gfLBitV;
@@ -12333,18 +12345,8 @@ int gpioGlitchFilter(unsigned gpio, unsigned steady)
 
    if (steady)
    {
-      gpioAlert[gpio].gfTick  = systReg[SYST_CLO];
-
-      if (gpioRead_Bits_0_31() & (1<<gpio))
-      {
-         gpioAlert[gpio].gfLBitV = (1<<gpio);
-         gpioAlert[gpio].gfRBitV = 0 ;
-      }
-      else
-      {
-         gpioAlert[gpio].gfLBitV = 0 ;
-         gpioAlert[gpio].gfRBitV = (1<<gpio);
-      }
+      /* Initialise values next time we process alerts */
+      gpioAlert[gpio].gfInitialised = 0;
    }
 
    gpioAlert[gpio].gfSteadyUs = steady;

--- a/x_pigpio.py
+++ b/x_pigpio.py
@@ -1028,6 +1028,8 @@ def td():
 
    tdcb1.cancel()
    tdcb2.cancel()
+   pi.set_glitch_filter(GPIO, 0)
+   pi.set_glitch_filter(GPIO2, 0)
 
 parser = argparse.ArgumentParser(description="test the Python I/F to the pigpio daemon")
 parser.add_argument("tests", nargs="?",

--- a/x_pigpio.py
+++ b/x_pigpio.py
@@ -11,6 +11,7 @@
 #* many failures in a group of tests indicate a problem.    *
 #************************************************************
 
+import argparse
 import sys
 import time
 import struct
@@ -1007,17 +1008,26 @@ def td():
 
    tdcb.cancel()
 
-if len(sys.argv) > 1:
+parser = argparse.ArgumentParser(description="test the Python I/F to the pigpio daemon")
+parser.add_argument("tests", nargs="?",
+                    help="tests to run, e.g. 0123456789d")
+parser.add_argument("-a", "--address", default=None,
+                    help="IP address or hostname of Pi on which to run tests")
+args = parser.parse_args()
+
+if args.tests is None:
+   tests = "0123456789d"
+else:
    tests = ""
-   for C in sys.argv[1]:
+   for C in args.tests:
       c = C.lower()
       if c not in tests:
          tests += c
 
+if args.address is None:
+   pi = pigpio.pi()
 else:
-   tests = "0123456789d"
-
-pi = pigpio.pi()
+   pi = pigpio.pi(args.address)
 
 if pi.connected:
    print("Connected to pigpio daemon.")


### PR DESCRIPTION
This is addresses issue #350 by waiting to initialize the glitch filter values until samples are first processed for the glitch filter. This helps to avoid problems with timing between the `SYST_CLO` and sample `tick`s when setting `gfTick`.

I also added a test case onto the wavechain and filter test section (but could make it a separate test too). The test usually fails when `x_pigpio.py` is run remotely, but rarely does when run locally. I added a command line argument to `x_pigpio.py` to run with a remote Pi. All other tests pass with these changes.