### PR TITLE
Fixing possible fclose on null pointer

### DIFF
--- a/pigpio.c
+++ b/pigpio.c
@@ -13733,8 +13733,8 @@ unsigned gpioHardwareRevision(void)
             rev = ntohl(tmp);
             rev &= 0xFFFFFF; /* mask out warranty bit */
          }
+         fclose(filp);
       }
-      fclose(filp);
    }
 
    piCores = 0;


### PR DESCRIPTION
It is currently possible to run `fclose` on a null pointer when searching `/proc/device-tree` for the hardware revision. This patch moves the `fclose` inside of the null check.