### PR TITLE
pigpiod.service shutdown delay issue fix

### DIFF
--- a/util/pigpiod.service
+++ b/util/pigpiod.service
@@ -4,6 +4,7 @@ Description=Pigpio daemon
 [Service]
 Type=forking
 ExecStart=/usr/bin/pigpiod
+KillSignal=SIGKILL
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
pigpiod wrapped into a systemd service slows down Raspberry Pi shutdown - because systemd, by default, sends SIGTERM to terminate pigpiod and pigpiod often does not react to SIGTERM. Adding KillSignal=SIGKILL to pigpiod.service instructs systemd to stop pigpiod using SIGKILL, which kills pigpiod instantly and resolves the shutdown delay issue #274 for good. To reproduce the issue and test the fix:

Before fix
````bash
$ sudo systemctl start pigpiod
$ sudo systemctl stop pigpiod
  // long delay
$ 
````

After fix
````bash
$ sudo systemctl start pigpiod
$ sudo systemctl stop pigpiod
  // no delay
$ 
````