### PR TITLE
Drop PROT_EXEC flag from mmap

### DIFF
--- a/pigpio.c
+++ b/pigpio.c
@@ -7332,7 +7332,7 @@ static int initGrabLockFile(void)
 static uint32_t * initMapMem(int fd, uint32_t addr, uint32_t len)
 {
     return (uint32_t *) mmap(0, len,
-       PROT_READ|PROT_WRITE|PROT_EXEC,
+       PROT_READ|PROT_WRITE,
        MAP_SHARED|MAP_LOCKED,
        fd, addr);
 }


### PR DESCRIPTION
For security reasons, newer distros mount /dev with 'noexec' so mmap with
PROT_EXEC will no longer work (Operation not permitted). There is really
no valid reason for pigpio to mmap with PROT_EXEC so drop the flag.

Signed-off-by: Juerg Haefliger <juergh@canonical.com>