### PR TITLE
Add support for BCM2711 high peripheral mode

### DIFF
--- a/pigpio.c
+++ b/pigpio.c
@@ -13797,9 +13797,9 @@ unsigned gpioHardwareRevision(void)
                {
                   pi_peri_phys = 0x47e000000; /* change to I/O peri base */
                }
-            }
 
-            fclose(filp);
+               fclose(filp);
+            }
 
             if ((pi_peri_phys != 0xFE000000) && (pi_peri_phys != 0x47E000000))
             {


### PR DESCRIPTION
High peripheral mode moves the peripherals out of the first 4GB of address space. This restores the full 35-bit address map with peripherals at 0x47C000000. Only works on 64-bit kernels for technical reasons but you gain 64MB of RAM. Userland can be 32-bit or 64-bit.