### PR TITLE
Change argument type of `pigpio_start` from `char*` to `const char*`

### DIFF
--- a/pigpiod_if2.c
+++ b/pigpiod_if2.c
@@ -234,7 +234,7 @@ static int pigpio_command_ext
    return cmd.res;
 }
 
-static int pigpioOpenSocket(char *addrStr, char *portStr)
+static int pigpioOpenSocket(const char *addrStr, const char *portStr)
 {
    int sock, err, opt;
    struct addrinfo hints, *res, *rp;
@@ -685,7 +685,7 @@ void stop_thread(pthread_t *pth)
    }
 }
 
-int pigpio_start(char *addrStr, char *portStr)
+int pigpio_start(const char *addrStr, const char *portStr)
 {
    int pi;
    int *userdata;

--- a/pigpiod_if2.h
+++ b/pigpiod_if2.h
@@ -429,7 +429,7 @@ The thread to be stopped should have been started with [*start_thread*].
 D*/
 
 /*F*/
-int pigpio_start(char *addrStr, char *portStr);
+int pigpio_start(const char *addrStr, const char *portStr);
 /*D
 Connect to the pigpio daemon.  Reserving command and
 notification streams.

--- a/x_pigpiod_if2.c
+++ b/x_pigpiod_if2.c
@@ -77,6 +77,10 @@ void t1(int pi)
    gpio_write(pi, GPIO, PI_HIGH);
    v = gpio_read(pi, GPIO);
    CHECK(1, 6, v, 1, 0, "write, read");
+
+   v = pigpio_start(PI_DEFAULT_SOCKET_ADDR_STR, PI_DEFAULT_SOCKET_PORT_STR);
+   CHECK(1, 7, v, 31, 100, "pigpio_start with non-default arguments");
+   pigpio_stop(v);
 }
 
 int t2_count=0;


### PR DESCRIPTION
PR related to issue #374 
This change will allow to use `pigpio_start` with string literals arguments. Current solution forbids it.
All tests from `x_pigpio, x_pigpiod_if2, x_pigpio.py, x_pigs, x_pipe` passed.
New test case added in `x_pigpiod_if2` to prove proper behavior of changed `pigpio_start` function.