### PR TITLE
changed doc to say it returns current PWM dutycycle instead of 0

### DIFF
--- a/pigpiod_if2.3
+++ b/pigpiod_if2.3
@@ -949,7 +949,7 @@ user_gpio: 0-31.
 .br
 
 .br
-Returns 0 if OK, otherwise PI_BAD_USER_GPIO or PI_NOT_PWM_GPIO.
+Returns current PWM dutycycle if OK, otherwise PI_BAD_USER_GPIO or PI_NOT_PWM_GPIO.
 
 .br
 

--- a/pigpiod_if2.h
+++ b/pigpiod_if2.h
@@ -568,7 +568,8 @@ Return the PWM dutycycle in use on a GPIO.
 user_gpio: 0-31.
 . .
 
-Returns 0 if OK, otherwise PI_BAD_USER_GPIO or PI_NOT_PWM_GPIO.
+Returns current PWM dutycycle if OK, 
+otherwise PI_BAD_USER_GPIO or PI_NOT_PWM_GPIO.
 
 For normal PWM the dutycycle will be out of the defined range
 for the GPIO (see [*get_PWM_range*]).


### PR DESCRIPTION
Chnaged docs in pigpiod_if.h and pigpiod_if2.3