### PR TITLE
docs: fix simple typo, receieve -> receive

### DIFF
--- a/pigpio.h
+++ b/pigpio.h
@@ -3071,7 +3071,7 @@ pages 165-166 of the Broadcom peripherals document for full
 details.
 
 SSSSS @ number of bytes successfully copied to transmit FIFO
-RRRRR @ number of bytes in receieve FIFO
+RRRRR @ number of bytes in receive FIFO
 TTTTT @ number of bytes in transmit FIFO
 RB    @ receive busy
 TE    @ transmit FIFO empty

--- a/pigpio.py
+++ b/pigpio.py
@@ -3677,7 +3677,7 @@ class pi():
       details.
 
       SSSSS @ number of bytes successfully copied to transmit FIFO
-      RRRRR @ number of bytes in receieve FIFO
+      RRRRR @ number of bytes in receive FIFO
       TTTTT @ number of bytes in transmit FIFO
       RB    @ receive busy
       TE    @ transmit FIFO empty

--- a/pigpiod_if2.h
+++ b/pigpiod_if2.h
@@ -3612,7 +3612,7 @@ pages 165-166 of the Broadcom peripherals document for full
 details.
 
 SSSSS @ number of bytes successfully copied to transmit FIFO
-RRRRR @ number of bytes in receieve FIFO
+RRRRR @ number of bytes in receive FIFO
 TTTTT @ number of bytes in transmit FIFO
 RB    @ receive busy
 TE    @ transmit FIFO empty


### PR DESCRIPTION
There is a small typo in pigpio.h, pigpio.py, pigpiod_if2.h.

Should read `receive` rather than `receieve`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md