### PR TITLE
Fix detection of whether or not the system is a raspberry pi.

### DIFF
--- a/pigpio.c
+++ b/pigpio.c
@@ -13754,7 +13754,7 @@ unsigned gpioHardwareRevision(void)
 
    if ((rev & 0x800000) == 0) /* old rev code */
    {
-      if (rev < 0x0016) /* all BCM2835 */
+      if ((rev > 0) && (rev < 0x0016)) /* all BCM2835 */
       {
          pi_ispi = 1;
          piCores = 1;


### PR DESCRIPTION
It seems that the new revision checking code fails to actually check if the system is in-fact a raspberry pi.

Specifically if both methods of reading the revision code fail (indicating that the system is probably not a raspberry pi), the logic that decodes the revision number still sets pi_ispi.

This code adds a >0 check so that does not happen.