### PR TITLE
Allow building on 64-bit system using lib64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,8 @@ generate_export_header(${PROJECT_NAME})
 
 install(TARGETS pigpio pigpiod_if pigpiod_if2 pig2vcd pigpiod pigs
     EXPORT ${PROJECT_NAME}Targets
-	LIBRARY  DESTINATION lib
-	ARCHIVE  DESTINATION lib
+	LIBRARY  DESTINATION lib${LIB_SUFFIX}
+	ARCHIVE  DESTINATION lib${LIB_SUFFIX}
 	RUNTIME  DESTINATION bin
 	INCLUDES DESTINATION include
 )


### PR DESCRIPTION
Fedora uses /usr/lib64 on 64-bit systems. Allow easy configuration in
cmake to install to correct directories.