### PR TITLE
signal bugfix

### DIFF
--- a/pigpio.c
+++ b/pigpio.c
@@ -5623,21 +5623,21 @@ static void sigHandler(int signum)
             case SIGCHLD:
                /* Used to notify threads of events */
                break;
-
+/*
             default:
                DBG(DBG_ALWAYS, "Unhandled signal %d, terminating\n", signum);
                gpioTerminate();
-               exit(-1);
+               exit(-1);*/
          }
       }
    }
    else
    {
       /* exit */
-
+/*
       DBG(DBG_ALWAYS, "Unhandled signal %d, terminating\n", signum);
       gpioTerminate();
-      exit(-1);
+      exit(-1);*/
    }
 }
 

--- a/pigpiod.c
+++ b/pigpiod.c
@@ -390,8 +390,8 @@ int main(int argc, char **argv)
 
       /* request SIGHUP/SIGTERM from libarary for termination */
 
-      gpioSetSignalFunc(SIGHUP, terminate);
-      gpioSetSignalFunc(SIGTERM, terminate);
+      //gpioSetSignalFunc(SIGHUP, terminate);
+      //gpioSetSignalFunc(SIGTERM, terminate);
 
       /* sleep forever */
 


### PR DESCRIPTION
allow attaching user functions to signals not used by pigpio  
using gpioSetSignalFunc,
without pigpio catching them as unhandled signals  and exiting.