### PR TITLE
gpioCfgSetInternals now returns PI_INITIALISED after gpioInitialise

### DIFF
--- a/pigpio.c
+++ b/pigpio.c
@@ -14023,6 +14023,7 @@ uint32_t gpioCfgGetInternals(void)
 
 int gpioCfgSetInternals(uint32_t cfgVal)
 {
+   if (libInitialised) return PI_INITIALISED;
    gpioCfg.internals = cfgVal;
    gpioCfg.dbgLevel = cfgVal & 0xF;
    gpioCfg.alertFreq = (cfgVal>>4) & 0xF;

--- a/pigpiod_if2.h
+++ b/pigpiod_if2.h
@@ -592,8 +592,8 @@ user_gpio: 0-31.
     range: 25-40000.
 . .
 
-Returns 0 if OK, otherwise PI_BAD_USER_GPIO, PI_BAD_DUTYRANGE,
-or PI_NOT_PERMITTED.
+Returns the actual range for the current gpio frequency if OK, 
+otherwise PI_BAD_USER_GPIO, PI_BAD_DUTYRANGE, or PI_NOT_PERMITTED.
 
 Notes
 


### PR DESCRIPTION
This resolves #455 with the discussion with @guymcswain that
gpioCfgSetInternals() should return an error if gpioInitialise()
has been called previously to report that it's no longer possible,
for example, to disable signal handling. If successful it returns
0 as before. Tested it by calling gpioCfgSetInternals, gpioInitialise,
gpioCfgSetInternals and reports 0 and -32 which looks OK.