### PR TITLE
Add warning regarding reusing wave ids in flight

### DIFF
--- a/pigpio.h
+++ b/pigpio.h
@@ -2078,6 +2078,9 @@ end of a cycle or finish before starting the new waveform.
 WARNING: bad things may happen if you delete the previous
 waveform before it has been synced to the new waveform.
 
+WARNING: bad things may happen if the same wave_id is queued
+more than once before it has finished sending.
+
 NOTE: Any hardware PWM started by [*gpioHardwarePWM*] will be cancelled.
 
 . .


### PR DESCRIPTION
I'm inspecting the source a little and it looks like this is the current situation:
- if a wave at the end of the queue, possibly being actively transmitted, is added again with SYNC, it will be relinked to its start, and it will loop forever with no error returned.  This is because waveEndPtr points to its own upcoming next pointer from its last transmission. https://github.com/joan2937/pigpio/blob/accd69d2fdd3404a0c56416912d87b2619d58563/pigpio.c#L9918
- if a wave already queued is added with SYNC, its next pointer will be re-mutated and everything on the queue after its previous position effectively dropped, with no error returned.  This is because its next pointer was previously holding a role in the chain of waves.  https://github.com/joan2937/pigpio/blob/accd69d2fdd3404a0c56416912d87b2619d58563/pigpio.c#L9912

Ideally it would be an error to transmit a wave with SYNC that is still queued to be sent.