### PR TITLE
Errno reset

### DIFF
--- a/pigpio.c
+++ b/pigpio.c
@@ -7299,6 +7299,8 @@ static void initCheckLockFile(void)
    char str[20];
 
    fd = open(PI_LOCKFILE, O_RDONLY);
+   if(errno == ENOENT)
+      errno = 0; // reset if expected error occured
 
    if (fd != -1)
    {


### PR DESCRIPTION
fixes #508 

`errno` is always set after a call to `gpioInitialise` due to `open` being used to check for the existance of the PID file in `initCheckLockFile`

This PR resets `errno` when the expected error occurs.