### PR TITLE
Improve signal handling.

### DIFF
--- a/pigpio.h
+++ b/pigpio.h
@@ -6528,6 +6528,11 @@ after this command is issued.
 #define PI_CMD_INTERRUPTED -144 // Used by Python
 #define PI_NOT_ON_BCM2711  -145 // not available on BCM2711
 #define PI_ONLY_ON_BCM2711 -146 // only available on BCM2711
+#define PI_NOSIGHANDLER    -147 // signal handling is disabled (gpioCfg.internals)
+#define PI_SIGNUM_INVALID  -148 // invalid signal number requested (signal.h)
+#define PI_SIGNUM_SET      -149 // handler for signal is already installed
+#define PI_SIG_UNK_ACTION  -150 // default signal handler is not installed
+#define PI_SIG_SKIPPED     -151 // set/cancel signal handler is not allowed
 
 #define PI_PIGIF_ERR_0    -2000
 #define PI_PIGIF_ERR_99   -2099


### PR DESCRIPTION
I.  The pigpio library's default signal handler is changed:

- DMA engines are stopped
- PID lockfile is removed
- The system default handler (SIG_DFL) is re-installed
- The signal is raised again (with `Term` disposition, see II).

The philosophy here is to do only the essential halting of the DMA engines and avoid any functions that are not signal-safe.

II.  The default signal handler is installed only for signals:

- Having SIG_DFL as the current handler.  This prevents signals having been ignored or previously installed with custom handlers from getting overridden.
- Having `Term` disposition as defined in signal(7).

III. SIGPIPE, SIGCHLD and SIGWINCH are ignored as before.

IV. SIGUSR1, SIGUSR2 are custom handlers as before.

V.  API `gpioSetSignalFunc()` can set / cancel custom handlers on any signal **except**:

- Any signal that was ignored prior to `gpioInitialize()` or as listed in III.
- Any signal that was preset prior to `gpioInitialise()`.

A cancelled signal will have its previous handler, which may be the library's default handler,  re-installed.

VI. Upon `gpioTerminate()`, any signal installed by the library will be restored to its original handler.  (issue #341)
