### PR TITLE
Expose serial number

### DIFF
--- a/DOC/src/defs/pigs.def
+++ b/DOC/src/defs/pigs.def
@@ -343,6 +343,7 @@ UTILITIES
 
 H/HELP  :: Display command help        ::
 HWVER   :: Get hardware version        :: gpioHardwareRevision
+SERNM   :: Get hardware serial number  :: gpioHardwareSerialNumber
 MICS v  :: Microseconds delay          :: gpioDelay
 MILS v  :: Milliseconds delay          :: gpioDelay
 PIGPV   :: Get pigpio library version  :: gpioVersion
@@ -1257,6 +1258,19 @@ for "Revision : 000g" the command returns 0.
 ...
 $ pigs hwver # On a B+
 16
+...
+
+SERNM ::
+This command returns the hardware serial number of the Pi.
+
+The hardware serial number is found on the serial line of /proc/cpuinfo.
+
+If the hardware revision can not be found or is not a valid hexadecimal
+number the command returns 0.
+
+...
+$ pigs sernm
+571858502
 ...
 
 I2CC ::

--- a/DOC/src/html/sif.html
+++ b/DOC/src/html/sif.html
@@ -1006,6 +1006,22 @@ uint32_t spi_flags<br></td>
 <td valign="top">4*X<br></td>
 <td valign="top">uint32_t pars[X]<br></td>
 </tr>
+<!--tr>
+<td valign="top">WVCAP<br></td>
+<td valign="top">118<br></td>
+<td valign="top">todo<br></td>
+<td valign="top">todo<br></td>
+<td valign="top">todo<br></td>
+<td valign="top">todo<br></td>
+</tr!-->
+<tr>
+<td valign="top">SERNM<br></td>
+<td valign="top">117<br></td>
+<td valign="top">script_id<br></td>
+<td valign="top">0<br></td>
+<td valign="top">4*X<br></td>
+<td valign="top">uint32_t pars[X]<br></td>
+</tr>
 </tbody>
 </table>
 <h3><a name="Response" id="Response"></a>Response</h3>
@@ -1982,6 +1998,22 @@ uint8_t data[X]</td>
 <td valign="top">-<br></td>
 <td valign="top">-<br></td>
 <td valign="top">0<br></td>
+<td valign="top">-<br></td>
+</tr>
+<!--tr>
+<td valign="top">WVCAP<br></td>
+<td valign="top">118<br></td>
+<td valign="top">-<br></td>
+<td valign="top">-<br></td>
+<td valign="top">wave id<br></td>
+<td valign="top">-<br></td>
+</tr-->
+<tr>
+<td valign="top">SERNM *<br></td>
+<td valign="top">119<br></td>
+<td valign="top">-<br></td>
+<td valign="top">-<br></td>
+<td valign="top">serial number<br></td>
 <td valign="top">-<br></td>
 </tr>
 </tbody>

--- a/command.c
+++ b/command.c
@@ -94,6 +94,7 @@ cmdInfo_t cmdInfo[]=
    {PI_CMD_HP,    "HP",    131, 0, 1}, // gpioHardwarePWM
 
    {PI_CMD_HWVER, "HWVER", 101, 4, 1}, // gpioHardwareRevision
+   {PI_CMD_SERNM, "SERNM", 101, 4, 1}, // gpioHardwareSerialNumber
 
    {PI_CMD_I2CC,  "I2CC",  112, 0, 1}, // i2cClose
    {PI_CMD_I2CO,  "I2CO",  131, 2, 1}, // i2cOpen
@@ -307,6 +308,7 @@ H/HELP           Display command help\n\
 HC g f           Set hardware clock frequency\n\
 HP g f dc        Set hardware PWM frequency and dutycycle\n\
 HWVER            Get hardware version\n\
+SERNM            Get hardware serial number\n\
 \n\
 I2CC h           Close I2C handle\n\
 I2CO bus device flags | Open I2C bus and device with flags\n\
@@ -671,7 +673,7 @@ int cmdParse(
       case 101: /* BR1  BR2  CGI  H  HELP  HWVER
                    DCRA  HALT  INRA  NO
                    PIGPV  POPA  PUSHA  RET  T  TICK  WVBSY  WVCLR
-                   WVCRE  WVGO  WVGOR  WVHLT  WVNEW
+                   WVCRE  WVGO  WVGOR  WVHLT  WVNEW SERNM
 
                    No parameters, always valid.
                 */

--- a/pigpio.3
+++ b/pigpio.3
@@ -10733,6 +10733,8 @@ A 16-bit word value.
 .br
 #define PI_CMD_WVCAP 118
 .br
+#define PI_CMD_SERNM 119
+.br
 
 .br
 

--- a/pigpio.c
+++ b/pigpio.c
@@ -2096,6 +2096,8 @@ static int myDoCommand(uintptr_t *p, unsigned bufSize, char *buf)
          break;
 
       case PI_CMD_HWVER: res = gpioHardwareRevision(); break;
+      
+      case PI_CMD_SERNM: res = gpioHardwareSerialNumber(); break;
 
 
 
@@ -13845,6 +13847,41 @@ unsigned gpioHardwareRevision(void)
    return rev;
 }
 
+
+unsigned int gpioHardwareSerialNumber(void)
+{
+   static unsigned serial = 0;
+
+   FILE * filp;
+   char buf[512];
+   char term;
+
+   DBG(DBG_USER, "");
+
+   if (serial) return serial;
+
+   filp = fopen ("/proc/cpuinfo", "r");
+
+
+   if (filp != NULL)
+   {
+      while (fgets(buf, sizeof(buf), filp) != NULL)
+      {
+         if (!strncasecmp("serial\t\t: ", buf, 10))
+         {
+            if (sscanf(buf+10, "%x%c", &serial, &term) == 2)
+            {
+               if (term != '\n') serial = 0;
+            }
+         }
+      }
+      fclose(filp);
+   }
+
+   DBG(DBG_USER, "serial number=%x", serial);
+
+   return serial;
+}
 
 /* ----------------------------------------------------------------------- */
 

--- a/pigpio.h
+++ b/pigpio.h
@@ -4298,6 +4298,7 @@ for "Revision       : 000f" the function returns 15.
 for "Revision       : 000g" the function returns 0.
 D*/
 
+unsigned int gpioHardwareSerialNumber(void);
 
 /*F*/
 unsigned gpioVersion(void);
@@ -6317,6 +6318,7 @@ PARAMS*/
 #define PI_CMD_PROCU 117
 #define PI_CMD_WVCAP 118
 
+#define PI_CMD_SERNM 119
 /*DEF_E*/
 
 /*

--- a/pigpio.py
+++ b/pigpio.py
@@ -317,6 +317,7 @@ UTILITIES
 get_current_tick          Get current tick (microseconds)
 
 get_hardware_revision     Get hardware revision
+get_hardware_serial_number     Get hardware serial number
 get_pigpio_version        Get the pigpio version
 
 pigpio.error_text         Gets error text from error number
@@ -573,6 +574,7 @@ _PI_CMD_EVT  =116
 
 _PI_CMD_PROCU=117
 _PI_CMD_WVCAP=118
+_PI_CMD_SERNM=119
 
 # pigpio error numbers
 
@@ -2088,6 +2090,29 @@ class pi():
       ...
       """
       return _pigpio_command(self.sl, _PI_CMD_HWVER, 0, 0)
+
+   def get_hardware_serial_number(self):
+      """
+      Returns the Pi's hardware serial number in decimal base.
+
+      The hardware serial number is the last few characters on the
+      Serial line of /proc/cpuinfo.
+
+      If the hardware revision can not be found or is not a valid
+      hexadecimal number the function returns 0.
+
+      ...
+      print(pi.get_hardware_serial_number())
+      571858502
+      ...
+
+      To get the hexadecimal value as displayed in /proc/cpuinfo:
+      ...
+      print("0x{:016x}".format(pi.get_hardware_serial_number()))
+      0x000000002215de46
+      """
+      return _pigpio_command(self.sl, _PI_CMD_SERNM, 0, 0)
+
 
    def get_pigpio_version(self):
       """
@@ -5669,7 +5694,7 @@ def xref():
 
    percent:: 0-100
    The size of waveform as percentage of maximum available.
-   
+
    port:
    The port used by the pigpio daemon, defaults to 8888.
 

--- a/pigpiod_if.c
+++ b/pigpiod_if.c
@@ -668,6 +668,9 @@ uint32_t get_current_tick(void)
 uint32_t get_hardware_revision(void)
    {return pigpio_command(gPigCommand, PI_CMD_HWVER, 0, 0, 1);}
 
+uint32_t get_hardware_sernum(void)
+   {return pigpio_command(gPigCommand, PI_CMD_SERNM, 0, 0, 1);}
+
 uint32_t get_pigpio_version(void)
    {return pigpio_command(gPigCommand, PI_CMD_PIGPV, 0, 0, 1);}
 

--- a/pigpiod_if2.c
+++ b/pigpiod_if2.c
@@ -886,6 +886,9 @@ uint32_t get_current_tick(int pi)
 uint32_t get_hardware_revision(int pi)
    {return pigpio_command(pi, PI_CMD_HWVER, 0, 0, 1);}
 
+uint32_t get_hardware_serial_number(int pi)
+   {return pigpio_command(pi, PI_CMD_SERNM, 0, 0, 1);}
+
 uint32_t get_pigpio_version(int pi)
    {return pigpio_command(pi, PI_CMD_PIGPV, 0, 0, 1);}
 

--- a/pigs.1
+++ b/pigs.1
@@ -589,7 +589,10 @@ Get waveform pulse stats
 Display command help        
 .P
 .B HWVER  
-Get hardware version        
+Get hardware version
+.P
+.B SERNM
+Get hardware serial number
 .P
 .B MICS v 
 Microseconds delay          
@@ -2254,6 +2257,32 @@ $ pigs hwver # On a B+
 .br
 16
 .br
+
+.br
+
+.IP "\fBSERNM \fP - Get hardware serial number"
+.IP "" 4
+This command returns the hardware serial number of the Pi.
+
+.br
+The hardware serial number is found on the serial line of /proc/cpuinfo.
+
+
+.br
+If the hardware serial number can not be found or is not a valid hexadecimal
+number the command returns 0.
+
+.br
+
+\fBExample\fP
+.br
+
+.EX
+$ pigs sernm
+.br
+571858502
+.br
+
 
 .EE
 

--- a/x_pigpio.c
+++ b/x_pigpio.c
@@ -50,6 +50,8 @@ void t0()
    printf("pigpio version %d.\n", gpioVersion());
 
    printf("Hardware revision %d.\n", gpioHardwareRevision());
+   
+   printf("Hardware serialnumber %u.\n", gpioHardwareSerialNumber());
 }
 
 void t1()

--- a/x_pigs
+++ b/x_pigs
@@ -55,6 +55,9 @@ if [[ ${#s} = 5423 ]]; then echo "HELP ok"; else echo "HELP fail (${#s})"; fi
 s=$(pigs hwver)
 if [[ $s -ne 0 ]]; then echo "HWVER ok"; else echo "HWVER fail ($s)"; fi
 
+s=$(pigs sernm)
+if [[ $s -ne 0 ]]; then echo "SERNM ok"; else echo "SERNM fail ($s)"; fi
+
 s=$(pigs mics 1000)
 if [[ $s = "" ]]; then echo "MICS ok"; else echo "MICS fail ($s)"; fi
 

--- a/x_pipe
+++ b/x_pipe
@@ -76,6 +76,10 @@ echo "hwver" >/dev/pigpio
 read -t 1 s </dev/pigout
 if [[ $s -ne 0 ]]; then echo "HWVER ok"; else echo "HWVER fail ($s)"; fi
 
+echo "sernm" >/dev/pigpio
+read -t 1 s </dev/pigout
+if [[ $s -ne 0 ]]; then echo "SERNM ok"; else echo "SERNM fail ($s)"; fi
+
 echo "mics 1000" >/dev/pigpio
 read -t 1 s </dev/pigout
 if [[ $s = 0 ]]; then echo "MICS ok"; else echo "MICS fail ($s)"; fi


### PR DESCRIPTION
Hello Guy,
As discussed in Issue #555 , this pull request adds the ability to obtain the serial number of the board.

The change is implemented in a similar fashion as the code extracting the hardware version. A new function gpioHardwareSerialNumber() is added for this purpose in pigpio.c (kept separated from gpioHardwareRevision() intentionally).

The pull request also includes:
- update to the tests (which are passing, at least with the hardware I have around to test with).
- update to the python module
- update to the documentation

Regarding the documentation update, I must admit not being very familiar with the various formats.
They do compile without warning, but if the update is not appropriate, thanks to let me know.
Also, I have spotted that WVCAP wasn't documented properly in sif.html - I have added the tr corresponding, but left it commented, as I wasn't knowing enough about this specific function to document it properly. 

Thanks