### PR TITLE
Allow the specification of the installation prefix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ LL2      = -L. -lpigpiod_if -pthread -lrt
 
 LL3      = -L. -lpigpiod_if2 -pthread -lrt
 
-prefix = /usr/local
+# Set prefix=/usr to overwrite distributed version
+prefix ?= /usr/local
 exec_prefix = $(prefix)
 bindir = $(exec_prefix)/bin
 includedir = $(prefix)/include


### PR DESCRIPTION
This makes it possible to install pigpio over the distributed version by running make prefix=/usr.