### PR TITLE
Fix license classifier

### DIFF
--- a/cmake/setup.py.in
+++ b/cmake/setup.py.in
@@ -18,6 +18,7 @@ setup(name='pigpio',
       classifiers=[
          "Programming Language :: Python :: 2",
          "Programming Language :: Python :: 3",
+         "License :: OSI Approved :: The Unlicense (Unlicense)",
       ],
       package_dir={ '': '${CMAKE_CURRENT_SOURCE_DIR}'}
      )

--- a/cmake/setup.py.in
+++ b/cmake/setup.py.in
@@ -12,13 +12,12 @@ setup(name='pigpio',
       description='Raspberry Pi GPIO module',
       long_description='Raspberry Pi Python module to access the pigpio daemon',
       download_url='http://abyz.me.uk/rpi/pigpio/pigpio.zip',
-      license='unlicense.org',
+      license='Unlicense',
       py_modules=['pigpio'],
       keywords=['raspberrypi', 'gpio',],
       classifiers=[
          "Programming Language :: Python :: 2",
          "Programming Language :: Python :: 3",
-         "License :: OSI Approved :: The Unlicense (Unlicense)",
       ],
       package_dir={ '': '${CMAKE_CURRENT_SOURCE_DIR}'}
      )


### PR DESCRIPTION
Hey 👋🏻,

I am currently looking into licensing at Home Assistant, and I found that we could not detect the license of this library properly. According to pyproject.toml documentation about the `license` field:
> If you are using a standard, well-known license, it is not necessary to use this field. Instead, you should use one of the [classifiers](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#classifiers) starting with License ::. (As a general rule, it is a good idea to use a standard, well-known license, both to avoid confusion and because some organizations avoid software whose license is unapproved.)

If you could do a release after this PR, and maybe bump in Home Assistant, that would be awesome :)