### PR TITLE
Update dht11.py to correctly implement the iterator protocol in Python 3

### DIFF
--- a/EXAMPLES/Python/DHT11_SENSOR/dht11.py
+++ b/EXAMPLES/Python/DHT11_SENSOR/dht11.py
@@ -140,7 +140,7 @@ class DHT11(object):
         """
         return self
 
-    def next(self):
+    def __next__(self):
         """
         Call the read method and return temperature and humidity informations.
         """


### PR DESCRIPTION
Your DHT11 class does not correctly implement the iterator protocol in Python 3.

In Python 3, the special method to get the next element of an iterator is called __next__() instead of next().

Therefore, to fix this issue, you need to rename the next() method to __next__() in your DHT11 class.