### PR TITLE
Update dht11.py - (patch-2) - specify the exception to raise

### DIFF
--- a/EXAMPLES/Python/DHT11_SENSOR/dht11.py
+++ b/EXAMPLES/Python/DHT11_SENSOR/dht11.py
@@ -88,7 +88,7 @@ class DHT11(object):
                 total = self.humidity + self.temperature
                 # is checksum ok ?
                 if not (total & 255) == self.checksum:
-                    raise
+                    raise ValueError("Checksum incorrect")
         elif 16 <= self.bit < 24: # in temperature byte
             self.temperature = (self.temperature << 1) + val
         elif 0 <= self.bit < 8: # in humidity byte


### PR DESCRIPTION
In Python, simply using raise outside of an except block is not valid and results in the error `RuntimeError: No active exception to reraise.`

By simply replacing `raise` with `raise ValueError("Checksum incorrect")`, you specify the exception to raise, which will eliminate the `RuntimeError`.
