### PR TITLE
Offset added for Pi 4B HW: 0xc03115 using  BCM2711

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.5)
 project(rrpigpio LANGUAGES C VERSION 0.71)
 
-list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 find_package(Threads REQUIRED)
 find_package(RT REQUIRED)
@@ -10,50 +10,20 @@ option(BUILD_SHARED_LIBS "Create shared libraries" ON)
 
 add_compile_options(-Wall)
 
-# libpigpio.(so|a)
-add_library(pigpio pigpio.c command.c custom.cext)
-
-# libpigpiod_if.(so|a)
-add_library(pigpiod_if pigpiod_if.c command.c)
-
-# libpigpiod_if2.(so|a)
-add_library(pigpiod_if2 pigpiod_if2.c command.c)
-
-# x_pigpio
-add_executable(x_pigpio x_pigpio.c)
-target_link_libraries(x_pigpio pigpio RT::RT Threads::Threads)
-
-# x_pigpiod_if
-add_executable(x_pigpiod_if x_pigpiod_if.c)
-target_link_libraries(x_pigpiod_if pigpiod_if RT::RT Threads::Threads)
-
-# x_pigpiod_if2
-add_executable(x_pigpiod_if2 x_pigpiod_if2.c)
-target_link_libraries(x_pigpiod_if2 pigpiod_if2 RT::RT Threads::Threads)
-
-# pigpiod
-add_executable(pigpiod pigpiod.c)
-target_link_libraries(pigpiod pigpio RT::RT Threads::Threads)
-
-# pigs
-add_executable(pigs pigs.c command.c)
-target_link_libraries(pigs Threads::Threads)
-
-# pig2vcd
-add_executable(pig2vcd pig2vcd.c command.c)
-target_link_libraries(pig2vcd Threads::Threads)
+# librrpigpio.(so|a)
+add_library(rrpigpio pigpio.c command.c custom.cext)
+target_link_libraries(rrpigpio RT::RT Threads::Threads)
 
 # Configure and install project
 include(GenerateExportHeader)
 include(CMakePackageConfigHelpers)
 
-generate_export_header(pigpio)
+generate_export_header(rrpigpio)
 
-install(TARGETS pigpio pigpiod_if pigpiod_if2 pig2vcd pigpiod pigs
+install(TARGETS rrpigpio
     EXPORT rrpigpioTargets
-    LIBRARY  DESTINATION lib${LIB_SUFFIX}
-    ARCHIVE  DESTINATION lib${LIB_SUFFIX}
-    RUNTIME  DESTINATION bin
+    LIBRARY DESTINATION lib${LIB_SUFFIX}
+    ARCHIVE DESTINATION lib${LIB_SUFFIX}
     INCLUDES DESTINATION include
 )
 
@@ -79,32 +49,15 @@ install(EXPORT rrpigpioTargets
 install(
     FILES
         ${CMAKE_CURRENT_LIST_DIR}/cmake/rrpigpioConfig.cmake
+		${CMAKE_CURRENT_LIST_DIR}/cmake/FindRT.cmake
         "${CMAKE_CURRENT_BINARY_DIR}/rrpigpioConfigVersion.cmake"
     DESTINATION
         ${ConfigPackageLocation}
 )
 
-install(FILES pigpio.h pigpiod_if.h pigpiod_if2.h
+install(FILES pigpio.h
     DESTINATION include
-    PERMISSIONS OWNER_READ OWNER_WRITE
-        GROUP_READ
-        WORLD_READ
-)
-
-file(GLOB man_1_SRC "*.1")
-install(FILES ${man_1_SRC}
-    DESTINATION man/man1
-    PERMISSIONS OWNER_READ OWNER_WRITE
-        GROUP_READ
-        WORLD_READ
-)
-
-file(GLOB man_3_SRC "*.3")
-install(FILES ${man_3_SRC}
-    DESTINATION man/man3
-    PERMISSIONS OWNER_READ OWNER_WRITE
-        GROUP_READ
-        WORLD_READ
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
 )
 
 # package project

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,16 +112,27 @@ install(FILES ${man_3_SRC}
 )
 
 # Install python modules.
-find_package(Python COMPONENTS Interpreter QUIET)
+# find_package(Python COMPONENTS Interpreter QUIET)
 
-if(Python_FOUND)
-	configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake/setup.py.in
-		${CMAKE_CURRENT_BINARY_DIR}/setup.py
-	)
+# if(Python_FOUND)
+# 	configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake/setup.py.in
+# 		${CMAKE_CURRENT_BINARY_DIR}/setup.py
+# 	)
 
-	install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py install)")
-endif()
+# 	install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py install)")
+# endif()
 
 # package project
+set(CPACK_PACKAGE_NAME "rrpigpio")
+set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
+set(CPACK_PACKAGE_ARCHITECTURE "${CMAKE_SYSTEM_PROCESSOR}")
+set(CPACK_DEBIAN_PACKAGE_MAINTAINER "Aaron Spiteri <azzmosphere@gmail.com>")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libc6")
+set(CPACK_DEBIAN_PACKAGE_SECTION "libs")
+set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "pigpio library (Ryder Robots fork)
+ Unofficial fork of pigpio with BCM2711 fixes.
+ Based on pigpio by Joan (joan2937).
+ NOT supported by the original author.")
+set(CPACK_GENERATOR "DEB")
 
 include (CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.0)
-
-project(pigpio LANGUAGES C VERSION 0.71)
+project(rrpigpio LANGUAGES C VERSION 0.71)
 
 list (APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
@@ -45,82 +44,68 @@ add_executable(pig2vcd pig2vcd.c command.c)
 target_link_libraries(pig2vcd Threads::Threads)
 
 # Configure and install project
+include(GenerateExportHeader)
+include(CMakePackageConfigHelpers)
 
-include (GenerateExportHeader)
-include (CMakePackageConfigHelpers)
-
-generate_export_header(${PROJECT_NAME})
+generate_export_header(pigpio)
 
 install(TARGETS pigpio pigpiod_if pigpiod_if2 pig2vcd pigpiod pigs
-    EXPORT ${PROJECT_NAME}Targets
-	LIBRARY  DESTINATION lib${LIB_SUFFIX}
-	ARCHIVE  DESTINATION lib${LIB_SUFFIX}
-	RUNTIME  DESTINATION bin
-	INCLUDES DESTINATION include
+    EXPORT rrpigpioTargets
+    LIBRARY  DESTINATION lib${LIB_SUFFIX}
+    ARCHIVE  DESTINATION lib${LIB_SUFFIX}
+    RUNTIME  DESTINATION bin
+    INCLUDES DESTINATION include
 )
 
 write_basic_package_version_file(
-	"${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-	VERSION ${${PROJECT_NAME}_VERSION}
-	COMPATIBILITY AnyNewerVersion
+    "${CMAKE_CURRENT_BINARY_DIR}/rrpigpioConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY AnyNewerVersion
 )
 
-export(EXPORT ${PROJECT_NAME}Targets
-  FILE "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Targets.cmake"
-  NAMESPACE pigpio::
+export(EXPORT rrpigpioTargets
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/rrpigpioTargets.cmake"
+    NAMESPACE rrpigpio::
 )
 
-set(ConfigPackageLocation lib/cmake/${PROJECT_NAME})
-install(EXPORT ${PROJECT_NAME}Targets
-  FILE
-    ${PROJECT_NAME}Targets.cmake
-  NAMESPACE
-    pigpio::
-  DESTINATION
-    ${ConfigPackageLocation}
+set(ConfigPackageLocation lib/cmake/rrpigpio)
+
+install(EXPORT rrpigpioTargets
+    FILE rrpigpioTargets.cmake
+    NAMESPACE rrpigpio::
+    DESTINATION ${ConfigPackageLocation}
 )
 
 install(
-  FILES
-    ${CMAKE_CURRENT_LIST_DIR}/cmake/${PROJECT_NAME}Config.cmake
-    "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-  DESTINATION
-    ${ConfigPackageLocation}
+    FILES
+        ${CMAKE_CURRENT_LIST_DIR}/cmake/rrpigpioConfig.cmake
+        "${CMAKE_CURRENT_BINARY_DIR}/rrpigpioConfigVersion.cmake"
+    DESTINATION
+        ${ConfigPackageLocation}
 )
 
 install(FILES pigpio.h pigpiod_if.h pigpiod_if2.h
-	DESTINATION include
-	PERMISSIONS OWNER_READ OWNER_WRITE
-		GROUP_READ
-		WORLD_READ
+    DESTINATION include
+    PERMISSIONS OWNER_READ OWNER_WRITE
+        GROUP_READ
+        WORLD_READ
 )
 
 file(GLOB man_1_SRC "*.1")
 install(FILES ${man_1_SRC}
-	DESTINATION man/man1
-	PERMISSIONS OWNER_READ OWNER_WRITE
-		GROUP_READ
-		WORLD_READ
+    DESTINATION man/man1
+    PERMISSIONS OWNER_READ OWNER_WRITE
+        GROUP_READ
+        WORLD_READ
 )
 
 file(GLOB man_3_SRC "*.3")
 install(FILES ${man_3_SRC}
-	DESTINATION man/man3
-	PERMISSIONS OWNER_READ OWNER_WRITE
-		GROUP_READ
-		WORLD_READ
+    DESTINATION man/man3
+    PERMISSIONS OWNER_READ OWNER_WRITE
+        GROUP_READ
+        WORLD_READ
 )
-
-# Install python modules.
-# find_package(Python COMPONENTS Interpreter QUIET)
-
-# if(Python_FOUND)
-# 	configure_file(${CMAKE_CURRENT_LIST_DIR}/cmake/setup.py.in
-# 		${CMAKE_CURRENT_BINARY_DIR}/setup.py
-# 	)
-
-# 	install(CODE "execute_process(COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/setup.py install)")
-# endif()
 
 # package project
 set(CPACK_PACKAGE_NAME "rrpigpio")
@@ -135,4 +120,4 @@ set(CPACK_DEBIAN_PACKAGE_DESCRIPTION "pigpio library (Ryder Robots fork)
  NOT supported by the original author.")
 set(CPACK_GENERATOR "DEB")
 
-include (CPack)
+include(CPack)

--- a/cmake/rrpigpioConfig.cmake
+++ b/cmake/rrpigpioConfig.cmake
@@ -1,2 +1,6 @@
+include(CMakeFindDependencyMacro)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}")
+find_dependency(Threads)
+find_dependency(RT)
 include(${CMAKE_CURRENT_LIST_DIR}/rrpigpioTargets.cmake)
-set(rrpigpio_TARGETS rrpigpio::pigpio)
+set(rrpigpio_TARGETS rrpigpio::rrpigpio)

--- a/cmake/rrpigpioConfig.cmake
+++ b/cmake/rrpigpioConfig.cmake
@@ -1,0 +1,2 @@
+include(${CMAKE_CURRENT_LIST_DIR}/rrpigpioTargets.cmake)
+set(rrpigpio_TARGETS rrpigpio::pigpio)

--- a/pigpio.c
+++ b/pigpio.c
@@ -1233,6 +1233,7 @@ static volatile uint32_t clk_plld_freq = CLK_PLLD_FREQ;
 static volatile uint32_t hw_pwm_max_freq = PI_HW_PWM_MAX_FREQ;
 static volatile uint32_t hw_clk_min_freq = PI_HW_CLK_MIN_FREQ;
 static volatile uint32_t hw_clk_max_freq = PI_HW_CLK_MAX_FREQ;
+static volatile uint32_t pi_gpio_sysfs_base = 0; 
 
 static int libInitialised = 0;
 
@@ -11913,7 +11914,7 @@ static void *pthISRThread(void *x)
       isr->gpio, isr->edge, isr->timeout, (uintptr_t)isr->func,
       isr->ex, (uintptr_t)isr->userdata);
 
-   sprintf(buf, "/sys/class/gpio/gpio%d/value", isr->gpio);
+   sprintf(buf, "/sys/class/gpio/gpio%d/value", isr->gpio + pi_gpio_sysfs_base);
 
    isr->fd = -1; /* no fd assigned */
 
@@ -11988,11 +11989,11 @@ static int intGpioSetISRFunc(
          if (fd < 0) return PI_BAD_ISR_INIT;
 
          /* ignore write fail if already exported */
-         sprintf(buf, "%d\n", gpio);
+         sprintf(buf, "%d\n", gpio + pi_gpio_sysfs_base);
          err = write(fd, buf, strlen(buf));
          close(fd);
 
-         sprintf(buf, "/sys/class/gpio/gpio%d/direction", gpio);
+         sprintf(buf, "/sys/class/gpio/gpio%d/direction", gpio + pi_gpio_sysfs_base);
          fd = open(buf, O_WRONLY);
          if (fd < 0) return PI_BAD_ISR_INIT;
 
@@ -12009,7 +12010,7 @@ static int intGpioSetISRFunc(
 
       if (gpioISR[gpio].edge != edge)
       {
-         sprintf(buf, "/sys/class/gpio/gpio%d/edge", gpio);
+         sprintf(buf, "/sys/class/gpio/gpio%d/edge", gpio + pi_gpio_sysfs_base);
          fd = open(buf, O_WRONLY);
          if (fd < 0) return PI_BAD_ISR_INIT;
 
@@ -12059,7 +12060,7 @@ static int intGpioSetISRFunc(
       {
          fd = open("/sys/class/gpio/unexport", O_WRONLY);
          if (fd < 0) return PI_BAD_ISR_INIT;
-         sprintf(buf, "%d\n", gpio);
+         sprintf(buf, "%d\n", gpio + pi_gpio_sysfs_base);
          err = write(fd, buf, strlen(buf));
          close(fd);
          if (err != strlen(buf)) return PI_BAD_ISR_INIT;
@@ -14012,6 +14013,7 @@ unsigned gpioHardwareRevision(void)
             pi_peri_phys = 0x3F000000;
             pi_dram_bus  = 0xC0000000;
             pi_mem_flag  = 0x04;
+            pi_gpio_sysfs_base = 0;
             break;
 
          case 0x3:   /* BCM2711 */
@@ -14026,6 +14028,7 @@ unsigned gpioHardwareRevision(void)
             hw_pwm_max_freq = PI_HW_PWM_MAX_FREQ_2711;
             hw_clk_min_freq = PI_HW_CLK_MIN_FREQ_2711;
             hw_clk_max_freq = PI_HW_CLK_MAX_FREQ_2711;
+            pi_gpio_sysfs_base = 512;
             break;
 
          default:
@@ -14040,6 +14043,7 @@ unsigned gpioHardwareRevision(void)
    DBG(DBG_USER, "pi_peri_phys=%x", pi_peri_phys);
    DBG(DBG_USER, "pi_dram_bus=%x", pi_dram_bus);
    DBG(DBG_USER, "pi_mem_flag=%x", pi_mem_flag);
+   DBG(DBG_USER, "pi_gpio_sysfs_base=%x", pi_gpio_sysfs_base);
 
    return rev;
 }


### PR DESCRIPTION
## STEPS TO REPRODUCE

Created MakeLists.txt file which linked as follows:

```text
# Find the path to the pigpio includes
find_path(pigpio_INCLUDE_DIR 
  NAMES pigpio.h
  HINTS /usr/local/include)

# Find the pigpio libraries
find_library(pigpio_LIBRARY 
  NAMES libpigpio.so pigpio
  HINTS /usr/local/lib)

...
include_directories(${pigpio_INCLUDE_DIRS})
...
add_executable(tst_motor_enc
  src/tst_motor_enc.cpp
  src/motor.cpp
  src/encoder.cpp
)
target_compile_options(tst_motor_enc PRIVATE -Wimplicit-fallthrough)

target_link_libraries(tst_motor_enc
  ${pigpio_LIBRARIES}
  pthread
  rt
)
```

Code calls code as:

```cpp

static void cb(
    int gpio_pin,
    uint32_t delta_us,
    uint32_t tick,
    TickStatus tick_status)
{
    std::lock_guard<std::mutex> lock(cb_mutex);
    l_gpio_pin.push_back(gpio_pin);
    l_delta_us.push_back(delta_us);
    l_tick.push_back(tick);
    l_tick_status.push_back(tick_status);
}

...

// Static wrapper - required for C function pointer compatibility
void MotorEncoder::gpio_isr_func(int gpio, int level, uint32_t tick, void *userdata) {
    auto* self = static_cast<MotorEncoder*>(userdata);
    self->handle_interrupt(gpio, level, tick);
}

void MotorEncoder::handle_interrupt(int gpio, int level, uint32_t tick) {
    uint32_t delta_us = tick - last_tick_;
    TickStatus status = TickStatus::HEALTHY;

    switch (level) {
        case 2:
            status = TickStatus::TIMEOUT;
            last_tick_ = tick;
            break;
        case 1:
            if (delta_us < min_interval_us_) {
                status = TickStatus::NOISE_REJECTED;
            }
            last_tick_ = tick;
            break;
        default:
            status = TickStatus::UNEXPECTED;
    }

    tick_cb_(gpio, delta_us, tick, status);
}

...

    switch (gpioSetISRFuncEx(
            pin_,
            RISING_EDGE,  
            timeout_,            
            &MotorEncoder::gpio_isr_func,
            this
        )) {
        case 0:
            break;
        case PI_BAD_GPIO:
            return CallbackReturn::FAILURE;
        case PI_BAD_EDGE:
            return CallbackReturn::FAILURE;
        case PI_BAD_ISR_INIT:
            return CallbackReturn::FAILURE;
        default:
            return CallbackReturn::FAILURE;
    }
```


## SOFTWARE TYPES AND VERSIONS

Hardware revision: 0xc03115
Model number: 17
Expected model for Pi4B: 17

DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=24.04
DISTRIB_CODENAME=noble
DISTRIB_DESCRIPTION="Ubuntu 24.04.3 LTS"

## TESTING

```bash
sudo pigpiod
for t in x_pigpio.py x_pigs x_pipe; do ./${t}; done
sudo killall pigpiod
```

#### TEST RESULTS

```text
Testing pigpio pigs
pigpio version 79
BC1 ok
BC2 ok
BR1 ok
BR2 ok
BS1 ok
BS2 ok
HELP ok
HWVER ok
MICS ok
MILS ok
MODEG ok
MODES ok
NO(0) ok
NB(0) ok
NP(0) ok
NC(0) ok
PFG-a ok
PFG-b ok
PFS-a ok
PFS-b ok
PRG-a ok
PRG-b ok
PROC(0) ok
PROCR(0) ok
PROCP(0) ok
PROCS(0) ok
PROCD(0) ok
PRRG ok
PRS-a ok
PRS-b ok
PRS-c ok
PRS-d ok
PUD-a ok
PUD-b ok
PUD-c ok
PUD-d ok
PUD-e ok
PWM-a ok
GDC-a ok
PWM-b ok
GDC-b ok
PWM-c ok
GDC-c ok
PWM-d ok
READ-a ok
READ-b ok
READ-c ok
READ-d ok
READ-e ok
SERVO-a ok
GPW-a ok
SERVO-b ok
GPW-b ok
SERVO-c ok
GPW-c ok
SERVO-d ok
SLR-a ok
SLR-b ok
SLR-c ok
SLR-d ok
WVCRE ok
SLR-e ok
SLR-f ok
SLR-g ok
TICK ok
TRIG-a ok
TRIG-b ok
TRIG-c ok
TRIG-d ok
WDOG-a ok
WDOG-b ok
WRITE-a ok
WRITE-b ok
WRITE-c ok
WRITE-d ok
WVCLR ok
WVAS ok
WVAG ok
WVCRE ok
WVTX ok
WVBSY-a ok
WVBSY-b ok
WVHLT ok
WVBSY-c ok
WVTXR ok
WVBSY-d ok
WVHLT ok
WVBSY-e ok
WVSC-a ok
WVSC-b ok
WVSC-c ok
WVSM-a ok
WVSM-b ok
WVSM-c ok
WVSP-a ok
WVSP-b ok
WVSP-c ok
WVCAP-a ok
WVCAP-b ok
WVCAP-c ok
ERROR: No more CBs for waveform
WVCAP-d ok
WVCAP-e ok

Testing pigpio pipe I/F
pigpio version 79
BC1 ok
BC2 ok
BR1 ok
BR2 ok
BS1 ok
BS2 ok
HELP-a ok
HELP-b ok
HWVER ok
MICS ok
MILS ok
MODEG ok
MODES ok
NO(0) ok
NB(0) ok
NP(0) ok
NC(0) ok
PFG-a ok
PFG-b ok
PFS-a ok
PFS-b ok
PRG-a ok
PRG-b ok
PROC(0) ok
PROCR(0) ok
PROCP(0) ok
PROCS(0) ok
PROCD(0) ok
PRRG ok
PRS-a ok
PRS-b ok
PRS-c ok
PRS-d ok
PUD-a ok
PUD-b ok
PUD-c ok
PUD-d ok
PUD-e ok
PWM-a ok
GDC-a ok
PWM-b ok
GDC-b ok
PWM-c ok
GDC-c ok
PWM-d ok
READ-a ok
READ-b ok
READ-c ok
READ-d ok
READ-e ok
SERVO-a ok
GPW-a ok
SERVO-b ok
GPW-b ok
SERVO-c ok
GPW-c ok
SERVO-d ok
SLR-a ok
SLR-b ok
SLR-c ok
SLR-d ok
WVCRE ok
SLR-e ok
SLR-f ok
SLR-g ok
TICK ok
TRIG-a ok
TRIG-b ok
TRIG-c ok
TRIG-d ok
WDOG-a ok
WDOG-b ok
WRITE-a ok
WRITE-b ok
WRITE-c ok
WRITE-d ok
WVCLR ok
WVAS ok
WVAG ok
WVCRE ok
WVTX ok
WVBSY-a ok
WVBSY-b ok
WVHLT ok
WVBSY-c ok
WVTXR ok
WVBSY-d ok
WVHLT ok
WVBSY-e ok
WVSC-a ok
WVSC-b ok
WVSC-c ok
WVSM-a ok
WVSM-b ok
WVSM-c ok
WVSP-a ok
WVSP-b ok
WVSP-c ok
```
